### PR TITLE
refactor : HTML 구조가 다른 학과에 대한 전략 패턴을 이용한 캡슐화

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/enums/Department.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/enums/Department.java
@@ -62,7 +62,7 @@ public enum Department {
     FINE_ARTS("조형예술학부", "https://finearts.inu.ac.kr/finearts/4130/subview.do"),
     DESIGN("디자인학부", "https://design.inu.ac.kr/design/4016/subview.do"),
     PERFORMING_ART("공연예술학과", "https://uipa10.inu.ac.kr/uipa10/3957/subview.do"),
-    SPORTS_SCIENCE("스포츠과학부", "https://sports.inu.ac.kr/bbs/board.php?bo_table=sub5_1"), // 다름
+    SPORTS_SCIENCE("스포츠과학부", "https://sports.inu.ac.kr/bbs/board.php?bo_table=sub5_1"),
     HEALTH_EXERCISE("운동건강학부", "https://uiex.inu.ac.kr/uiex/4068/subview.do"),
 
     // 사범대학

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/DepartmentCrawlConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/DepartmentCrawlConfig.java
@@ -1,0 +1,19 @@
+package kr.inuappcenterportal.inuportal.global.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.jsoup.nodes.Element;
+
+import java.util.function.Predicate;
+
+@Getter
+@AllArgsConstructor
+public class DepartmentCrawlConfig {
+
+    private String titleSelector;
+    private String dateSelector;
+    private String linkSelector;
+    private String viewsSelector;
+    private Predicate<Element> skipCondition;
+    private boolean useAbsoluteHref;
+}


### PR DESCRIPTION
## 📎 관련 이슈

- ❌

## 📄 설명

> 일반 학과들과 스포츠 과학과의 HTML 구조가 다른 문제로 인해 비슷한 로직들이 중복된 두 개의 메서드가 사용됨

- DepartmentCrawlConfig를 도입
-> 메서드를 하나로 통일하고 일반 학과와 스포츠 과학과의 세팅 값을 설정해 메서드에 진입하도록 수정
-> 전략 패턴을 통해 공통 Config를 만들고 두 가지의 구현체가 교체하며 쓸 수 있도록 패턴화 / 캡슐화

## 🤔 추후 작업 사항

- ❌