### PR TITLE
fix: 회원 받은 알림 조회 type 고정 오류 수정

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/category/model/Category.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/category/model/Category.java
@@ -18,6 +18,8 @@ public class Category {
     @Column(nullable = false)
     private String category;
 
+    private String type;
+
     @Builder
     public Category(String category){
         this.category = category;

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/res/NotificationResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/res/NotificationResponse.java
@@ -23,8 +23,8 @@ public record NotificationResponse(
         FcmMessageType type
 
 ) {
-    public static NotificationResponse from(MemberFcmMessage memberFcmMessage, FcmMessage fcmMessage, FcmMessageType type) {
+    public static NotificationResponse from(MemberFcmMessage memberFcmMessage, FcmMessage fcmMessage) {
         return new NotificationResponse(fcmMessage.getId(), memberFcmMessage.getMemberId(),
-                fcmMessage.getTitle(), fcmMessage.getBody(), type);
+                fcmMessage.getTitle(), fcmMessage.getBody(), memberFcmMessage.getFcmMessageType());
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/model/MemberFcmMessage.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/model/MemberFcmMessage.java
@@ -1,6 +1,7 @@
 package kr.inuappcenterportal.inuportal.domain.firebase.model;
 
 import jakarta.persistence.*;
+import kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType;
 import kr.inuappcenterportal.inuportal.global.model.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,12 +23,17 @@ public class MemberFcmMessage extends BaseTimeEntity {
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    private MemberFcmMessage(Long fcmMessageId, Long memberId) {
+    @Column(name = "fcm_message_type")
+    @Enumerated(EnumType.STRING)
+    private FcmMessageType fcmMessageType;
+
+    private MemberFcmMessage(Long fcmMessageId, Long memberId, FcmMessageType fcmMessageType) {
         this.fcmMessageId = fcmMessageId;
         this.memberId = memberId;
+        this.fcmMessageType = fcmMessageType;
     }
 
-    public static MemberFcmMessage of(Long fcmMessageId, Long memberId) {
-        return new MemberFcmMessage(fcmMessageId, memberId);
+    public static MemberFcmMessage of(Long fcmMessageId, Long memberId, FcmMessageType fcmMessageType) {
+        return new MemberFcmMessage(fcmMessageId, memberId, fcmMessageType);
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈

- ❌

## 📄 설명

> 회원의 받은 알림 조회 시 type이 department로 고정되는 오류 발생

- 받은 알림 저장 시, type도 함께 저장
-> 관리자 알림일 경우 GENERAL
-> 학과 키워드 알림일 경우 DEPARTMENT

## 🤔 추후 작업 사항

- ❌