### PR TITLE
feat: 캐시 스탬피드 문제 해결 및 알림 기능 안정화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     implementation 'mysql:mysql-connector-java:8.0.32'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson:3.51.0'
 
     implementation 'org.jsoup:jsoup:1.15.3'
     implementation 'org.seleniumhq.selenium:selenium-java:4.18.1'

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/config/AsyncConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/config/AsyncConfig.java
@@ -16,6 +16,7 @@ public class AsyncConfig {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(1);
         executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(10);
         executor.setThreadNamePrefix("FCM-MSG-");
         executor.initialize();
         return executor;
@@ -23,9 +24,10 @@ public class AsyncConfig {
 
     @Bean(name = "sendExecutor")
     public Executor sendExecutor() {
+        int core = Runtime.getRuntime().availableProcessors();
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(8);
-        executor.setMaxPoolSize(16);
+        executor.setCorePoolSize(core);
+        executor.setMaxPoolSize(core * 2);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("FCM-SEND-");
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncExecutor.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncExecutor.java
@@ -1,15 +1,14 @@
 package kr.inuappcenterportal.inuportal.domain.firebase.service;
 
-import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Collections;
+
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 
@@ -17,9 +16,8 @@ import java.util.concurrent.CompletableFuture;
 @RequiredArgsConstructor
 @Slf4j
 public class FcmAsyncExecutor {
-    private final List<String> failedTokensList = Collections.synchronizedList(new ArrayList<>());
     @Async("sendExecutor")
-    public CompletableFuture<Void> sendMessage(List<String> tokens, String body, String title){
+    public CompletableFuture<Void> sendMessage(List<String> tokens, String body, String title, Set<String> failedTokensList){
         try {
             MulticastMessage message = MulticastMessage.builder()
                     .addAllTokens(tokens)
@@ -39,13 +37,5 @@ public class FcmAsyncExecutor {
             log.warn("비동기 알림 전송 실패 : {}",e.getMessage());
         }
         return CompletableFuture.completedFuture(null);
-    }
-
-    public List<String> getFailedTokensList(){
-        return failedTokensList;
-    }
-
-    public void clearFailedTokenSet(){
-        failedTokensList.clear();
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
@@ -1,5 +1,6 @@
 package kr.inuappcenterportal.inuportal.domain.post.service;
 
+import jakarta.annotation.PostConstruct;
 import kr.inuappcenterportal.inuportal.domain.category.repository.CategoryRepository;
 import kr.inuappcenterportal.inuportal.domain.member.model.Member;
 import kr.inuappcenterportal.inuportal.domain.member.repository.MemberRepository;
@@ -20,6 +21,8 @@ import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
 import kr.inuappcenterportal.inuportal.global.service.ImageService;
 import kr.inuappcenterportal.inuportal.global.service.RedisService;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
@@ -38,6 +41,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 @Service
@@ -57,6 +62,8 @@ public class PostService {
     private String path;
     private final CacheManager cacheManager;
     private final CacheManager localCacheManager;
+    private final RedissonClient redissonClient;
+    private final ReentrantLock lock = new ReentrantLock();
 
     public PostService(PostRepository postRepository,
                        MemberRepository memberRepository,
@@ -68,7 +75,8 @@ public class PostService {
                        ImageService imageService,
                        ReportRepository reportRepository,
                        @Qualifier("cacheManager") CacheManager cacheManager,
-                       @Qualifier("localCacheManager") CacheManager localCacheManager) {
+                       @Qualifier("localCacheManager") CacheManager localCacheManager,
+                       RedissonClient redissonClient) {
         this.postRepository = postRepository;
         this.memberRepository = memberRepository;
         this.likePostRepository = likePostRepository;
@@ -80,6 +88,7 @@ public class PostService {
         this.reportRepository = reportRepository;
         this.cacheManager = cacheManager;
         this.localCacheManager = localCacheManager;
+        this.redissonClient = redissonClient;
     }
 
     @Scheduled(cron = "0 0 0 * * *")
@@ -103,6 +112,15 @@ public class PostService {
         log.info("게시글 순서 랜덤화 작업 완료");
     }
 
+    @PostConstruct
+    public void warmUpData(){
+        warmUpCache();
+    }
+
+    @Scheduled(cron = "0 0 */3 * * ?")
+    public void warmUp(){
+        warmUpCache();
+    }
     @Transactional
     public Long savePost(Member member, PostDto postSaveDto, List<MultipartFile> images) throws NoSuchAlgorithmException, IOException {
         if(!categoryRepository.existsByCategory(postSaveDto.getCategory())){
@@ -385,48 +403,146 @@ public class PostService {
         return posts;
     }
 
-    @Transactional(readOnly = true)
+
     public List<PostListResponseDto> getRandomTop() {
         // 레디스 캐시 조회
         try {
-            Cache cache = cacheManager.getCache("randomPost");
-            List<PostListResponseDto> posts = cache.get("randomTop", List.class);
+            List<PostListResponseDto> posts = getRedisCachedData();
             if (posts != null) {
                 return posts;
             }
+            else{
+                // 레디스가 살아 있는 상태에서 캐시 조회 실패시 캐시 셋팅
+                return setRedisCache();
+            }
         } catch (Exception e) {
-            log.warn("랜덤 인기 게시글 - 레디스 캐시 조회 실패");
+            log.warn("랜덤 인기 게시글 - 레디스 다운으로 인한 조회 실패");
         }
+
         // 레디스 캐시 조회 실패 시 로컬 캐시 조회
-        try {
-            Cache cache = localCacheManager.getCache("randomPost");
-            List<PostListResponseDto> posts = cache.get("randomTop", List.class);
-            if (posts != null) {
-                return posts;
-            }
-        } catch (Exception e) {
-            log.warn("랜덤 인기 게시글 - 로컬 캐시 조회 실패");
+        List<PostListResponseDto> posts = getLocalCachedData();
+        if (posts != null) {
+            return posts;
         }
-        // 캐시 조회 실패 시 DB 접근
+        else{
+            return setLocalCache();
+        }
+    }
+
+    public List<PostListResponseDto> getRedisCachedData(){
+        Cache cache = cacheManager.getCache("randomPost");
+        return cache.get("randomTop", List.class);
+    }
+    public List<PostListResponseDto> getLocalCachedData(){
+        Cache cache = localCacheManager.getCache("randomPost");
+        return cache.get("randomTop", List.class);
+    }
+
+    private List<PostListResponseDto> setRedisCache(){
+        RLock lock = redissonClient.getLock("postLock");
+        List<PostListResponseDto> posts = null;
+        boolean locked = false;
+        try {
+            locked = lock.tryLock(500, 5000, TimeUnit.MILLISECONDS);
+            if(locked) {
+                // 캐시 갱신 완료시 로직 스킵
+                posts = getRedisCachedData();
+                if(posts==null) {
+                    // 캐시 조회 실패 시 DB 접근 후 레디스 캐시 등록
+                    posts = postRepository.findRandomTop().stream()
+                            .map(this::getPostListResponseDto)
+                            .collect(Collectors.toList());
+                    cacheManager.getCache("randomPost").put("randomTop", posts);
+                }
+            }
+            else{
+                // 락 획득 실패시 조회 재시도 4초동안 0.2초 간격으로 캐시 확인, 실패시 로컬 캐시 접근
+                int count = 0;
+                while (count < 20){
+                    posts = getRedisCachedData();
+                    if(posts!=null){
+                        return posts;
+                    }
+                    Thread.sleep(200);
+                    count++;
+                }
+                return setLocalCache();
+            }
+        }
+        catch (InterruptedException e){
+            Thread.currentThread().interrupt();
+            log.warn("락 대기 중 인터럽트 발생");
+        }
+        catch (Exception e){
+            // 레디스 다운 발생시 로컬 캐시 접근
+            posts = getLocalCachedData();
+            if(posts!=null) {
+                return setLocalCache();
+            }
+            return posts;
+        }
+        finally {
+            if (locked && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+        return posts;
+    }
+
+    private List<PostListResponseDto> setLocalCache(){
+        boolean locked = false;
+        List<PostListResponseDto> posts = null;
+        try {
+            locked = lock.tryLock(500,TimeUnit.MILLISECONDS);
+            if(locked) {
+                // 캐시 조회 실패 시 DB 접근 후 로컬 캐시 등록
+                // 캐시 갱신 완료시 로직 스킵
+                posts = getLocalCachedData();
+                if(posts==null) {
+                    posts = postRepository.findRandomTop().stream()
+                            .map(this::getPostListResponseDto)
+                            .collect(Collectors.toList());
+                    localCacheManager.getCache("randomPost").put("randomTop", posts);
+                }
+            }
+            else{
+                // 락 획득 실패시 조회 재시도
+                int count = 0;
+                while (count < 20){
+                    posts = getLocalCachedData();
+                    if(posts!=null){
+                        return posts;
+                    }
+                    Thread.sleep(200);
+                    count++;
+                }
+                // 로컬 캐시 데이터 조회에도 문제 발생 시 데이터베이스 문제로 판단하고 빈 데이터 전송
+                log.warn("로컬 캐시 조회 타임 아웃 발생 - 데이터베이스 ");
+                return null;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("락 대기 중 인터럽트 발생");
+        }
+        finally {
+            if(locked){
+                lock.unlock();
+            }
+        }
+        return posts;
+    }
+
+    public void warmUpCache(){
         List<PostListResponseDto> posts = postRepository.findRandomTop().stream()
                 .map(this::getPostListResponseDto)
                 .collect(Collectors.toList());
-        // 레디스 캐시 등록
-        try {
+        // 캐시 웜업 - 레디스 다운 시 로컬 캐시에 데이터 웜업
+        try{
             cacheManager.getCache("randomPost").put("randomTop", posts);
-            return posts;
-        } catch (Exception e) {
-            log.warn("랜덤 인기 게시글 - 레디스 캐시 저장 실패");
         }
-
-        // 레디스 캐시 등록 실패 시 로컬 캐시 등록
-        try {
+        catch (Exception e){
             localCacheManager.getCache("randomPost").put("randomTop", posts);
-        } catch (Exception e) {
-            log.warn("랜덤 인기 게시글 - 로컬 캐시 저장 실패 ");
         }
-
-        return posts;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/RedisCacheConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/RedisCacheConfig.java
@@ -27,7 +27,7 @@ public class RedisCacheConfig {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofHours(3L)); // 캐쉬 저장 시간 3시간 설정
+                .entryTtl(Duration.ofMinutes(185L)); // 캐쉬 저장 시간 3시간 5분 설정
 
         return RedisCacheManager
                 .RedisCacheManagerBuilder
@@ -42,7 +42,7 @@ public class RedisCacheConfig {
         caffeine.setAllowNullValues(false);
         caffeine.setCaffeine(Caffeine.newBuilder()
                 .maximumSize(20)
-                .expireAfterWrite(30, TimeUnit.MINUTES)); // 로컬 캐시 저장 시간 30분
+                .expireAfterWrite(185, TimeUnit.MINUTES)); // 로컬 캐시 저장 시간 30분
         return caffeine;
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/RedisConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package kr.inuappcenterportal.inuportal.global.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,5 +41,15 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setEnableTransactionSupport(true);
         return redisTemplate;
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisHost + ":" + redisPort)
+                .setTimeout(300);
+
+        return Redisson.create(config);
     }
 }


### PR DESCRIPTION
## 📄 설명

- 메인 화면에 나오는 랜덤한 인기 게시글에 캐싱에 대해 웜업 기능을 추가했습니다. 웜업 중 데이터베이스 연결 문제, 혹은 레디스 다운으로 인해 캐시가 없을 경우를 대비해 데이터 읽기에 직접 캐싱 및 리트라이 기능을 추가했습니다. 캐시 스탬피드 문제가 발생할 가능성이 있기에 레디스의 경우에는 레디슨을, 로컬 캐시의 경우에는 reentrantLock을 활용해 DB에는 최초 접속 스레드만 접근하게 설정했습니다.

- 알림 기능에서 전체 전송 기능 중 토큰 삭제 리스트를 모든 스레드에서 공유하기에 각 요청 별 토큰 삭제 리스트를 만들어 충돌 발생을 막았습니다.
- 알림 기능 비동기 전송 부분에서 하드 코딩된 스레드 풀 수를 현재 작동 환경 CPU 코어 수에서 설정하게 변경했습니다.

## 🤔 추후 작업 사항

- 데이터베이스 인덱스를 새로 설정할 예정입니다.