### PR TITLE
🐜 fix: 회원 전체 알림 전송 시 Exception null handling

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -204,7 +204,9 @@ public class FcmService {
         if (sendResponse.isSuccessful() && memberId != null) {
             memberFcmMessageList.add(MemberFcmMessage.of(fcmMessage.getId(), memberId, fcmMessageType));
         } else {
-            log.warn("FCM 전송 실패: token={}, error={}", token, sendResponse.getException().getMessage());
+            FirebaseMessagingException exception = sendResponse.getException();
+            String errorMsg = exception != null ? exception.getMessage() : "알 수 없는 오류 (exception=null)";
+            log.warn("FCM 전송 실패: token={}, error={}", token, errorMsg);
         }
     }
 


### PR DESCRIPTION
## 📎 관련 이슈

- ❌

## 📄 설명

> 관리자 알림 기능에서 전체 회원 알림 전송 시 알림 실패 Exception을 던지는 상황에서 NullPointerException 발생
- null 일 경우 알 수 없는 오류로 null 핸들링

## 🤔 추후 작업 사항

- ❌