### PR TITLE
🐜 fix: 전체 회원 알림 전송 시 memberId = NULL 값들 필터링 제거

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/repository/FcmTokenRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/repository/FcmTokenRepository.java
@@ -27,7 +27,4 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken,Long> {
 
     @Query("SELECT f FROM FcmToken f WHERE f.memberId IN :memberIds")
     List<FcmToken> findFcmTokensByMemberIds(@Param("memberIds") List<Long> memberIds);
-
-    @Query("SELECT f FROM FcmToken f WHERE f.memberId IS NOT null")
-    List<FcmToken> findAllActiveTokens();
 }


### PR DESCRIPTION
## 📎 관련 이슈

- ❌

## 📄 설명

> 전체 회원 대상 알림 전송 시 memberId = NULL인 값들에 대해서 필터링 로직이 존재
> 비로그인 회원은 알림이 전송되지 않음
- memberId = NULL인 값들도 로직에 포함
-> 알림은 전송, 알림 내역은 저장하지 않도록 구성

## 🤔 추후 작업 사항

- 전체 회원 대상 알림 전송 로직 테스트 필요