### PR TITLE
🐜 fix: 회원 기기가 여러개 일 경우 fcm_token 값이 중복되어 한 번에 여러개의 알림이 쌓이는 문제 수정

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -217,7 +217,15 @@ public class FcmService {
 
     private void saveMemberFcmMessage(List<MemberFcmMessage> memberFcmMessageList, int i, int batchSize) {
         List<MemberFcmMessage> batch = memberFcmMessageList.subList(i, Math.min(i + batchSize, memberFcmMessageList.size()));
-        memberFcmMessageRepository.saveAll(batch);
+
+        Map<Long, MemberFcmMessage> uniqueMemberFcmMessages = batch.stream()
+                        .collect(Collectors.toMap(
+                                MemberFcmMessage::getMemberId,
+                                m -> m,
+                                (existing, replacement) -> existing
+                        ));
+
+        memberFcmMessageRepository.saveAll(uniqueMemberFcmMessages.values());
         memberFcmMessageRepository.flush();
     }
 


### PR DESCRIPTION
## 📎 관련 이슈

- ❌

## 📄 설명

> 회원의 기기가 여러 개일 경우, fcm_token의 memberId 값이 중복
> 한 회원에게 여러 개의 알림이 저장되는 문제 발생
- 회원의 받은 알림을 저장할 때, memberId를 기반으로 필터링
-> 중복된 memberId 값에 대해서는 하나의 알림 ( fcm_message )가 저장되도록 수정

## 🤔 추후 작업 사항

-테스트 필요