### PR TITLE
✨ feat: 로깅 저장, 조회, 삭제 로직

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/InuPortalApplication.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/InuPortalApplication.java
@@ -39,6 +39,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableJpaAuditing
 @EnableScheduling
 @EnableCaching
+@EnableAsync
 @SpringBootApplication
 public class InuPortalApplication {
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/contorller/FcmController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/contorller/FcmController.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Min;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.req.AdminNotificationRequest;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.req.TokenRequestDto;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.res.NotificationResponse;
+import kr.inuappcenterportal.inuportal.domain.firebase.service.FcmAsyncService;
 import kr.inuappcenterportal.inuportal.domain.firebase.service.FcmService;
 import kr.inuappcenterportal.inuportal.domain.member.model.Member;
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class FcmController {
 
     private final FcmService fcmService;
+    private final FcmAsyncService fcmAsyncService;
 
     @PostMapping("")
     public ResponseEntity<ResponseDto<Long>> saveToken(@Valid@RequestBody TokenRequestDto tokenRequestDto, @AuthenticationPrincipal Member member){
@@ -52,7 +54,7 @@ public class FcmController {
                     "memberIds가 비어있으면 전체 회원에게 알림을 전송합니다.")
     @PostMapping("/admin")
     public ResponseEntity<ResponseDto<Long>> sendToMembers(@Valid @RequestBody AdminNotificationRequest request){
-        fcmService.sendToMembers(request);
+        fcmAsyncService.sendAsyncToMembers(request);
         if (request.memberIds() == null || request.memberIds().isEmpty())
             return ResponseEntity.status(HttpStatus.OK).body(ResponseDto.of(1L, "전체 회원 알림 전송 성공"));
         else

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
@@ -1,0 +1,25 @@
+package kr.inuappcenterportal.inuportal.domain.firebase.service;
+
+import kr.inuappcenterportal.inuportal.domain.firebase.dto.req.AdminNotificationRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class FcmAsyncService {
+
+    private final FcmService fcmService;
+
+    @Async("messageExecutor")
+    public void sendAsyncKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body) {
+        fcmService.sendKeywordNotice(tokenAndMemberId, title, body);
+    }
+
+    @Async("messageExecutor")
+    public void sendAsyncToMembers(AdminNotificationRequest request) {
+        fcmService.sendToMembers(request);
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -5,11 +5,11 @@ import com.google.firebase.messaging.*;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.req.AdminNotificationRequest;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.res.NotificationResponse;
 import kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType;
-import kr.inuappcenterportal.inuportal.domain.firebase.model.FcmToken;
 import kr.inuappcenterportal.inuportal.domain.firebase.model.FcmMessage;
+import kr.inuappcenterportal.inuportal.domain.firebase.model.FcmToken;
 import kr.inuappcenterportal.inuportal.domain.firebase.model.MemberFcmMessage;
-import kr.inuappcenterportal.inuportal.domain.firebase.repository.FcmTokenRepository;
 import kr.inuappcenterportal.inuportal.domain.firebase.repository.FcmMessageRepository;
+import kr.inuappcenterportal.inuportal.domain.firebase.repository.FcmTokenRepository;
 import kr.inuappcenterportal.inuportal.domain.firebase.repository.MemberFcmMessageRepository;
 import kr.inuappcenterportal.inuportal.domain.member.model.Member;
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
@@ -26,11 +26,13 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Service
 @Slf4j
@@ -130,7 +132,6 @@ public class FcmService {
     }
 
     @Transactional
-    @Async("messageExecutor")
     public void sendKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body) {
         if (tokenAndMemberId.isEmpty()) return;
 
@@ -140,7 +141,6 @@ public class FcmService {
     }
 
     @Transactional
-    @Async("messageExecutor")
     public void sendToMembers(AdminNotificationRequest request) {
         List<FcmToken> fcmTokens;
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/keyword/service/KeywordService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/keyword/service/KeywordService.java
@@ -1,10 +1,9 @@
 package kr.inuappcenterportal.inuportal.domain.keyword.service;
 
-import io.jsonwebtoken.impl.crypto.MacProvider;
 import kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType;
 import kr.inuappcenterportal.inuportal.domain.firebase.model.FcmToken;
 import kr.inuappcenterportal.inuportal.domain.firebase.repository.FcmTokenRepository;
-import kr.inuappcenterportal.inuportal.domain.firebase.service.FcmService;
+import kr.inuappcenterportal.inuportal.domain.firebase.service.FcmAsyncService;
 import kr.inuappcenterportal.inuportal.domain.keyword.domain.Keyword;
 import kr.inuappcenterportal.inuportal.domain.keyword.dto.res.KeywordResponse;
 import kr.inuappcenterportal.inuportal.domain.keyword.repository.KeywordRepository;
@@ -18,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -30,7 +28,7 @@ public class KeywordService {
 
     private final KeywordRepository keywordRepository;
     private final FcmTokenRepository fcmTokenRepository;
-    private final FcmService fcmService;
+    private final FcmAsyncService fcmAsyncService;
 
     @Transactional(readOnly = true)
     public List<KeywordResponse> getKeywords(Member member) {
@@ -58,7 +56,7 @@ public class KeywordService {
                 .filter(t -> t.getMemberId() != null)
                 .collect(Collectors.toMap(FcmToken::getToken, FcmToken::getMemberId));
 
-        fcmService.sendKeywordNotice(tokenAndMemberId, "[" + department.getDepartmentName() + "] 키워드에 맞는 새 공지사항이 등록되었습니다.", departmentNotice.getTitle());
+        fcmAsyncService.sendAsyncKeywordNotice(tokenAndMemberId, "[" + department.getDepartmentName() + "] 키워드에 맞는 새 공지사항이 등록되었습니다.", departmentNotice.getTitle());
     }
 
     @Transactional
@@ -72,7 +70,7 @@ public class KeywordService {
                 .filter(t -> t.getMemberId() != null)
                 .collect(Collectors.toMap(FcmToken::getToken, FcmToken::getMemberId));
 
-        fcmService.sendKeywordNotice(tokenAndMemberId, "[" + department.getDepartmentName() + "] 새로운 공지사항이 등록되었습니다.", departmentNotice.getTitle());
+        fcmAsyncService.sendAsyncKeywordNotice(tokenAndMemberId, "[" + department.getDepartmentName() + "] 새로운 공지사항이 등록되었습니다.", departmentNotice.getTitle());
     }
 
     @Transactional

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/AsyncConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/AsyncConfig.java
@@ -1,4 +1,4 @@
-package kr.inuappcenterportal.inuportal.domain.firebase.config;
+package kr.inuappcenterportal.inuportal.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +29,17 @@ public class AsyncConfig {
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("FCM-SEND-");
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "loggingExecutor")
+    public Executor loggingExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("LOGGING-");
         executor.initialize();
         return executor;
     }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/LoggingConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/LoggingConfig.java
@@ -2,6 +2,8 @@ package kr.inuappcenterportal.inuportal.global.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.global.logging.service.LoggingService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -18,7 +20,11 @@ import java.util.Set;
 @Slf4j
 @Aspect
 @Component
-public class Logging {
+@RequiredArgsConstructor
+public class LoggingConfig {
+
+    private final LoggingService loggingService;
+
     private static final Set<String> except_uri = Set.of(
             "/api/weathers",
             "/api/notices/top",
@@ -36,14 +42,16 @@ public class Logging {
         String httpMethod = request.getMethod();
 
         if (except_uri.contains(uri)) {
-
             return joinPoint.proceed();
         }
-        String memberId = getMemberId(request);
 
+        String memberId = getMemberId(request);
         long startTime = System.currentTimeMillis();
         Object result = joinPoint.proceed();
         long duration = System.currentTimeMillis() - startTime;
+
+        loggingService.saveLog(memberId, httpMethod, uri, duration);
+
         log.info("user={} {} {} {}ms", memberId, httpMethod, uri, duration);
 
         return result;

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/LoggingConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/LoggingConfig.java
@@ -2,7 +2,7 @@ package kr.inuappcenterportal.inuportal.global.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import kr.inuappcenterportal.inuportal.domain.member.model.Member;
-import kr.inuappcenterportal.inuportal.global.logging.service.LoggingService;
+import kr.inuappcenterportal.inuportal.global.logging.service.LoggingAsyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -23,7 +23,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class LoggingConfig {
 
-    private final LoggingService loggingService;
+    private final LoggingAsyncService loggingAsyncService;
 
     private static final Set<String> except_uri = Set.of(
             "/api/weathers",
@@ -50,7 +50,7 @@ public class LoggingConfig {
         Object result = joinPoint.proceed();
         long duration = System.currentTimeMillis() - startTime;
 
-        loggingService.saveLog(memberId, httpMethod, uri, duration);
+        loggingAsyncService.asyncSaveLog(memberId, httpMethod, uri, duration);
 
         log.info("user={} {} {} {}ms", memberId, httpMethod, uri, duration);
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/MySqlConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/MySqlConfig.java
@@ -21,8 +21,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
-@EnableTransactionManagement
-@EnableJpaRepositories(basePackages = {"kr.inuappcenterportal.inuportal.domain"})
+@EnableTransactionManagement@EnableJpaRepositories(basePackages = {
+        "kr.inuappcenterportal.inuportal.domain",
+        "kr.inuappcenterportal.inuportal.global.logging.repository"
+})
 @Profile("!test")
 public class MySqlConfig {
     @Bean(name = "dataSource")
@@ -38,7 +40,10 @@ public class MySqlConfig {
         Map<String, String> properties = new HashMap<String, String>();
         properties.put("hibernate.hbm2ddl.auto", "update");
 
-        return builder.dataSource(dataSource).packages("kr.inuappcenterportal.inuportal.domain").persistenceUnit("primary").properties(properties).build();
+        return builder.dataSource(dataSource).packages(
+                "kr.inuappcenterportal.inuportal.domain",
+                "kr.inuappcenterportal.inuportal.global.logging.domain"
+        ).persistenceUnit("primary").properties(properties).build();
     }
 
     @Primary

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/images","/api/images/**","/api/categories","/api/councilNotices","/api/councilNotices/**","/api/books/**", "/api/items/**", "/api/lost/**","/api/clubs/**").hasRole("ADMIN")
                         .requestMatchers("/api/keywords/**").hasAnyRole("USER","ADMIN")
                         .requestMatchers("/api/tokens/admin").hasRole("ADMIN")
+                        .requestMatchers("/api/logs/**").hasAnyRole("ADMIN")
                 );
         httpSecurity
                 .addFilterBefore(new JwtAuthenticationFilter(tokenProvider,objectMapper), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/controller/LoggingController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/controller/LoggingController.java
@@ -8,6 +8,7 @@ import kr.inuappcenterportal.inuportal.global.logging.service.LoggingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,12 +24,14 @@ public class LoggingController {
     private final LoggingService loggingService;
 
     @Operation(summary = "특정 날짜 접속 회원 Id 수와 목록 조회", description = "[관리자 전용] 특정 날짜에 접속한 회원 Id의 수와 목록을 조회합니다.")
+    @GetMapping("/members")
     public ResponseEntity<ResponseDto<LoggingMemberResponse>> getMemberLogsByDate(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date ) {
         return ResponseEntity.ok(ResponseDto.of(loggingService.getMemberLogsByDate(date), date + ": 회원 로그 조회 성공"));
     }
 
     @Operation(summary = "가장 많이 호출된 API 순위", description = "[관리자 전용] 특정 날짜에 호출된 API의 순위를 조회합니다.")
+    @GetMapping("/apis")
     public ResponseEntity<ResponseDto<List<LoggingApiResponse>>> getLogsByDate(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date ) {
         return ResponseEntity.ok(ResponseDto.of(loggingService.getAPILogsByDate(date), date + ": api 로그 조회 성공"));

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/controller/LoggingController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/controller/LoggingController.java
@@ -1,0 +1,36 @@
+package kr.inuappcenterportal.inuportal.global.logging.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
+import kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingApiResponse;
+import kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingMemberResponse;
+import kr.inuappcenterportal.inuportal.global.logging.service.LoggingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/logs")
+public class LoggingController {
+
+    private final LoggingService loggingService;
+
+    @Operation(summary = "특정 날짜 접속 회원 Id 수와 목록 조회", description = "[관리자 전용] 특정 날짜에 접속한 회원 Id의 수와 목록을 조회합니다.")
+    public ResponseEntity<ResponseDto<LoggingMemberResponse>> getMemberLogsByDate(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date ) {
+        return ResponseEntity.ok(ResponseDto.of(loggingService.getMemberLogsByDate(date), date + ": 회원 로그 조회 성공"));
+    }
+
+    @Operation(summary = "가장 많이 호출된 API 순위", description = "[관리자 전용] 특정 날짜에 호출된 API의 순위를 조회합니다.")
+    public ResponseEntity<ResponseDto<List<LoggingApiResponse>>> getLogsByDate(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date ) {
+        return ResponseEntity.ok(ResponseDto.of(loggingService.getAPILogsByDate(date), date + ": api 로그 조회 성공"));
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/domain/Logging.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/domain/Logging.java
@@ -1,0 +1,40 @@
+package kr.inuappcenterportal.inuportal.global.logging.domain;
+
+import jakarta.persistence.*;
+import kr.inuappcenterportal.inuportal.global.model.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Logging extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id")
+    private String memberId;
+
+    @Column(name = "http_method", nullable = false)
+    private String httpMethod;
+
+    @Column(nullable = false)
+    private String uri;
+
+    @Column(nullable = false)
+    private long duration;
+
+    private Logging(String memberId, String httpMethod, String uri, long duration) {
+        this.memberId = memberId;
+        this.httpMethod = httpMethod;
+        this.uri = uri;
+        this.duration = duration;
+    }
+
+    public static Logging createLog(String memberId, String httpMethod, String uri, long duration) {
+        return new Logging(memberId, httpMethod, uri, duration);
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/domain/Logging.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/domain/Logging.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "logging")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Logging extends BaseTimeEntity {

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/dto/res/LoggingApiResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/dto/res/LoggingApiResponse.java
@@ -1,0 +1,15 @@
+package kr.inuappcenterportal.inuportal.global.logging.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "API 로그 응답")
+public record LoggingApiResponse(
+
+        @Schema(description = "호출된 uri")
+        String uri,
+
+        @Schema(description = "호출된 횟수")
+        Long apiCount
+
+) {
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/dto/res/LoggingMemberResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/dto/res/LoggingMemberResponse.java
@@ -1,0 +1,20 @@
+package kr.inuappcenterportal.inuportal.global.logging.dto.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "회원 로그 응답")
+public record LoggingMemberResponse(
+
+        @Schema(description = "회원 수")
+        Integer memberCount,
+
+        @Schema(description = "회원 Id 목록")
+        List<String> memberId
+
+) {
+    public static LoggingMemberResponse of(Integer memberCount, List<String> memberId) {
+        return new LoggingMemberResponse(memberCount, memberId);
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/repository/LoggingRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/repository/LoggingRepository.java
@@ -1,0 +1,31 @@
+package kr.inuappcenterportal.inuportal.global.logging.repository;
+
+import kr.inuappcenterportal.inuportal.global.logging.domain.Logging;
+import kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingApiResponse;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface LoggingRepository extends JpaRepository<Logging, Long> {
+
+    @Query("""
+    SELECT DISTINCT l.memberId
+    FROM Logging l
+    WHERE l.createDate = :createDate AND l.memberId IS NOT NULL
+""")
+    List<String> findDistinctMemberIdsByCreateDate(LocalDate createDate);
+
+    @Query("""
+    SELECT new kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingApiResponse(l.uri, COUNT(l.uri))
+    FROM Logging l
+    WHERE l.createDate = :createDate
+    GROUP BY l.uri
+    ORDER BY COUNT(l.uri) DESC
+""")
+    List<LoggingApiResponse> findApILogsByCreateDate(LocalDate createDate, Pageable pageable);
+
+    List<Logging> findAllByCreateDateBefore(LocalDate createDateBefore, Pageable pageable);
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingAsyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingAsyncService.java
@@ -1,0 +1,17 @@
+package kr.inuappcenterportal.inuportal.global.logging.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoggingAsyncService {
+
+    private final LoggingService loggingService;
+
+    @Async("loggingExecutor")
+    public void asyncSaveLog(String memberId, String httpMethod, String uri, long duration) {
+        loggingService.saveLog(memberId, httpMethod, uri, duration);
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
@@ -1,0 +1,78 @@
+package kr.inuappcenterportal.inuportal.global.logging.service;
+
+import kr.inuappcenterportal.inuportal.global.logging.domain.Logging;
+import kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingApiResponse;
+import kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingMemberResponse;
+import kr.inuappcenterportal.inuportal.global.logging.repository.LoggingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LoggingService {
+
+    private final LoggingRepository loggingRepository;
+    private final int BATCH_SIZE = 1000;
+
+    @Async
+    @Transactional
+    public void saveLog(String memberId, String httpMethod, String uri, long duration) {
+        loggingRepository.save(Logging.createLog(memberId, httpMethod, uri, duration));
+    }
+
+    @Transactional(readOnly = true)
+    public LoggingMemberResponse getMemberLogsByDate(LocalDate date) {
+        List<String> memberIds = loggingRepository.findDistinctMemberIdsByCreateDate(date);
+        Integer memberCount = memberIds.size();
+
+        return LoggingMemberResponse.of(memberCount, memberIds);
+    }
+
+    @Transactional(readOnly = true)
+    public List<LoggingApiResponse> getAPILogsByDate(LocalDate date) {
+        return loggingRepository.findApILogsByCreateDate(date, PageRequest.of(0, 10));
+    }
+
+    // 매일 새벽 4시에 실행
+    @Scheduled(cron = "0 0 4 * * *")
+    @Transactional
+    public void deleteOldLogs() {
+        LocalDate oneWeekAgo = LocalDate.now().minusWeeks(1);
+        log.info("일주일 전 로그 삭제 시작. 기준 날짜: {}", oneWeekAgo);
+
+        int deletedCount = 0;
+        int batchDeleted;
+
+        do {
+            batchDeleted = deleteNextBatchOfOldLogs(oneWeekAgo);
+            deletedCount += batchDeleted;
+        } while (batchDeleted > 0);
+
+        log.info("총 {}건의 오래된 로그 삭제 완료.", deletedCount);
+    }
+
+    // 트랜잭션 분리
+    @Transactional
+    public int deleteNextBatchOfOldLogs(LocalDate cutoffDate) {
+        List<Logging> logsToDelete =
+                loggingRepository.findAllByCreateDateBefore(cutoffDate, PageRequest.of(0, BATCH_SIZE));
+
+        if (logsToDelete.isEmpty()) {
+            return 0;
+        }
+
+        loggingRepository.deleteAllInBatch(logsToDelete);
+        loggingRepository.flush();
+
+        return logsToDelete.size();
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
@@ -7,7 +7,6 @@ import kr.inuappcenterportal.inuportal.global.logging.repository.LoggingReposito
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,6 @@ public class LoggingService {
     private final LoggingRepository loggingRepository;
     private final int BATCH_SIZE = 1000;
 
-    @Async
     @Transactional
     public void saveLog(String memberId, String httpMethod, String uri, long duration) {
         loggingRepository.save(Logging.createLog(memberId, httpMethod, uri, duration));


### PR DESCRIPTION
## 📎 관련 이슈

- closed #130 

## 📄 설명
> 다음과 같은 내역을 로그로 수집하고 조회하는 기능을 추가하고자 함
> - 특정 날짜에 접속한 회원의 수
> - 호출한 메서드 횟수
1. 로깅 출력과 동시에 로깅 저장
2. 특정 날짜의 접속 회원 수와 회원 id 조회 api
3. 특정 날짜의 가장 많이 호출된 api의 uri 상위 10개 조회 api
4. 일주일 이전의 로깅을 정리하는 스케줄링

## 🤔 추후 작업 사항

- 테스트 필요