### PR TITLE
🔧 chore : Api 로깅 기준에 http method 추가 / 커스텀 api 로그 저장 시 memberId 및 httpMethod 값 추가

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/LoggingConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/LoggingConfig.java
@@ -29,7 +29,8 @@ public class LoggingConfig {
             "/api/weathers",
             "/api/notices/top",
             "/api/posts/main",
-            "/api/members/refresh"
+            "/api/members/refresh",
+            "/api/logs/*"
     );
     @Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
     public void restControllerMethods() {}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/controller/LoggingController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/controller/LoggingController.java
@@ -1,8 +1,10 @@
 package kr.inuappcenterportal.inuportal.global.logging.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
 import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
 import kr.inuappcenterportal.inuportal.global.logging.dto.req.ApiLoggingRequest;
 import kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingApiResponse;
@@ -11,6 +13,7 @@ import kr.inuappcenterportal.inuportal.global.logging.service.LoggingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -41,7 +44,9 @@ public class LoggingController {
     @Operation(summary = "API 로그 저장", description = "직접 입력한 API 로그를 저장합니다. <br><br>" +
             "Api uri를 보내주세요. ex) /api/buses, /api/maps")
     @PostMapping("/apis")
-    public ResponseEntity<ResponseDto<String>> saveApiLogs(@Valid @RequestBody ApiLoggingRequest apiLoggingRequest) {
-        return ResponseEntity.ok(ResponseDto.of(loggingService.saveApiLogs(apiLoggingRequest), "Api 로그 저장 성공"));
+    public ResponseEntity<ResponseDto<String>> saveApiLogs(@Valid @RequestBody ApiLoggingRequest apiLoggingRequest,
+                                                           @AuthenticationPrincipal Member member,
+                                                           HttpServletRequest request) {
+        return ResponseEntity.ok(ResponseDto.of(loggingService.saveApiLogs(apiLoggingRequest, member, request), "Api 로그 저장 성공"));
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/domain/SummaryApiLogItem.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/domain/SummaryApiLogItem.java
@@ -22,15 +22,19 @@ public class SummaryApiLogItem {
     private Long apiCount;
 
     @Column(nullable = false, length = 50)
+    private String method;
+
+    @Column(nullable = false, length = 50)
     private String uri;
 
-    private SummaryApiLogItem(Long summaryApiLogId, Long apiCount, String uri) {
+    private SummaryApiLogItem(Long summaryApiLogId, Long apiCount, String method, String uri) {
         this.summaryApiLogId = summaryApiLogId;
         this.apiCount = apiCount;
+        this.method = method;
         this.uri = uri;
     }
 
-    public static SummaryApiLogItem of(Long summaryApiLogId, Long apiCount, String uri) {
-        return new SummaryApiLogItem(summaryApiLogId, apiCount, uri);
+    public static SummaryApiLogItem of(Long summaryApiLogId, Long apiCount, String method, String uri) {
+        return new SummaryApiLogItem(summaryApiLogId, apiCount, method, uri);
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/dto/res/LoggingApiResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/dto/res/LoggingApiResponse.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "API 로그 응답")
 public record LoggingApiResponse(
 
+        @Schema(description = "호출된 method")
+        String method,
+
         @Schema(description = "호출된 uri")
         String uri,
 
@@ -12,7 +15,7 @@ public record LoggingApiResponse(
         Long apiCount
 
 ) {
-    public static LoggingApiResponse of(String uri, Long apiCount) {
-        return new LoggingApiResponse(uri, apiCount);
+    public static LoggingApiResponse of(String method, String uri, Long apiCount) {
+        return new LoggingApiResponse(method, uri, apiCount);
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/repository/LoggingRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/repository/LoggingRepository.java
@@ -17,17 +17,17 @@ public interface LoggingRepository extends JpaRepository<Logging, Long> {
     WHERE l.createDate = :createDate
     AND l.memberId IS NOT NULL
     AND l.memberId <> '-1'
-    AND l.uri = '/api/members'
+    AND l.uri = '/api/members/no-dup'
 """)
     List<String> findDistinctMemberIdsByCreateDate(LocalDate createDate);
 
     @Query("""
-    SELECT new kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingApiResponse(l.uri, COUNT(l.uri))
+    SELECT new kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingApiResponse(l.httpMethod, l.uri, COUNT(l.uri))
     FROM Logging l
     WHERE l.createDate = :createDate
     AND l.uri NOT IN (:excludedUris)
-    GROUP BY l.uri
-    ORDER BY COUNT(l.uri) DESC
+    GROUP BY l.httpMethod, l.uri
+    ORDER BY COUNT(1) DESC
 """)
     List<LoggingApiResponse> findApILogsByCreateDate(LocalDate createDate, List<String> excludedUris, Pageable pageable);
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
@@ -59,7 +59,7 @@ public class LoggingService {
                     summaryApiLogItemRepository.findAllBySummaryApiLogId(summaryApiLogId);
 
             return summaryApiLogItems.stream().map(summaryApiLogItem ->
-                    LoggingApiResponse.of(summaryApiLogItem.getUri(), summaryApiLogItem.getApiCount())
+                    LoggingApiResponse.of(summaryApiLogItem.getMethod(), summaryApiLogItem.getUri(), summaryApiLogItem.getApiCount())
             ).collect(Collectors.toList());
         }
     }
@@ -98,7 +98,7 @@ public class LoggingService {
         SummaryApiLog summaryApiLog = summaryApiLogRepository.save(SummaryApiLog.from(oneDayAgo));
 
         List<SummaryApiLogItem> summaryApiLogItems = loggingApiResponses.stream()
-                .map(apiLog -> SummaryApiLogItem.of(summaryApiLog.getId(), apiLog.apiCount(), apiLog.uri()))
+                .map(apiLog -> SummaryApiLogItem.of(summaryApiLog.getId(), apiLog.apiCount(), apiLog.method(), apiLog.uri()))
                 .collect(Collectors.toList());
         summaryApiLogItemRepository.saveAll(summaryApiLogItems);
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
@@ -1,5 +1,7 @@
 package kr.inuappcenterportal.inuportal.global.logging.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
 import kr.inuappcenterportal.inuportal.global.logging.domain.*;
@@ -137,9 +139,12 @@ public class LoggingService {
     }
 
     @Transactional
-    public String saveApiLogs(ApiLoggingRequest apiLoggingRequest) {
+    public String saveApiLogs(ApiLoggingRequest apiLoggingRequest, Member member, HttpServletRequest request) {
+        String memberId = getClientId(member, request);
+        String httpMethod = "CUSTOM";
+
         return loggingRepository.save(
-                Logging.createLog("-1", "-1", apiLoggingRequest.uri(), -1)
+                Logging.createLog(memberId, httpMethod, apiLoggingRequest.uri(), -1)
         ).getUri();
     }
 
@@ -153,7 +158,15 @@ public class LoggingService {
     private List<LoggingApiResponse> getAPILogResponseByDate(LocalDate date) {
         return loggingRepository.findApILogsByCreateDate(date, EXCLUDED_URIS, PageRequest.of(0, 20));
     }
-  
+
+    private String getClientId(Member member, HttpServletRequest request) {
+        if (member != null) {
+            return member.getId().toString();
+        } else {
+            return request.getHeader("X-Forwarded-For");
+        }
+    }
+
     private static final List<String> EXCLUDED_URIS = List.of(
             "/v3/api-docs/swagger-config",
             "/v3/api-docs",

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,7 @@
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-        <file>/intip/logs/intip.log</file>
+        <file>intip/logs/intip.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>/intip/logs/intip.%d{yyyy-MM-dd}.log</fileNamePattern>


### PR DESCRIPTION
## 📎 관련 이슈

- closed #130 

## 📄 설명

- Api 로깅 기준에 Http Method 추가
-> 동일한 endpoint에서도 method로 호출 수를 구분하기 위함

- 커스텀 api 로그 저장 시 memberId 및 httpmethod 값 추가
-> 기존의 -1로 대체되던 값 구체화

## 🤔 추후 작업 사항

- ❌