### PR TITLE
Feat: 학과 공지사항 리턴 시 연관 일정 보유 여부 추가 및 학과공지id로 연관 일정 목록 조회

### DIFF
--- a/instagram-2gisik-scrapping/output/latest_post.json
+++ b/instagram-2gisik-scrapping/output/latest_post.json
@@ -1,0 +1,11 @@
+{
+  "username": "incheondae_2gisik",
+  "post_url": "https://www.instagram.com/incheondae_2gisik/p/DXGr3s3jkWF/",
+  "caption": "오늘 저녁은\n얼큰짬뽕탕\n바삭탕수육\n느타리야채볶음\n매콤두부조림\n김치와 흰쌀밥 입니다~^^♡",
+  "published_at_iso": "2026-04-14T07:55:36.000Z",
+  "published_at_display": "23분",
+  "like_count": 1,
+  "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/670148599_18524865223073374_7033240443613913848_n.webp?_nc_cat=111&ig_cache_key=Mzg3NDk3NzQ3MzE0Njc5OTQ5Mw%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTQ0MC5zZHIuQzMifQ%3D%3D&_nc_ohc=FrfdpWsKML4Q7kNvwH-FsSq&_nc_oc=Adr3wnJOw3pgto75CFLCymwozgzMlDxt4HhRD4CwlEk5rNGZCL7LlBrntDCErcBPJjg&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=1sNKEuHqfAPkUq_u_L0cig&_nc_ss=7a32e&oh=00_Af1StmGicUcgyKB7vxvnmnyOpL6Dt9ljIsegqn_TDWwJ3w&oe=69E3D346",
+  "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 14, 2026. May be an image of tofu, stew and text.",
+  "scraped_at_utc": "2026-04-14T08:19:26.269798+00:00"
+}

--- a/instagram-2gisik-scrapping/output/scraped_posts.json
+++ b/instagram-2gisik-scrapping/output/scraped_posts.json
@@ -1,0 +1,90 @@
+[
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DXGr3s3jkWF/",
+    "caption": "오늘 저녁은\n얼큰짬뽕탕\n바삭탕수육\n느타리야채볶음\n매콤두부조림\n김치와 흰쌀밥 입니다~^^♡",
+    "published_at_iso": "2026-04-14T07:55:36.000Z",
+    "published_at_display": "23분",
+    "like_count": 1,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/670148599_18524865223073374_7033240443613913848_n.webp?_nc_cat=111&ig_cache_key=Mzg3NDk3NzQ3MzE0Njc5OTQ5Mw%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTQ0MC5zZHIuQzMifQ%3D%3D&_nc_ohc=FrfdpWsKML4Q7kNvwH-FsSq&_nc_oc=Adr3wnJOw3pgto75CFLCymwozgzMlDxt4HhRD4CwlEk5rNGZCL7LlBrntDCErcBPJjg&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=1sNKEuHqfAPkUq_u_L0cig&_nc_ss=7a32e&oh=00_Af1StmGicUcgyKB7vxvnmnyOpL6Dt9ljIsegqn_TDWwJ3w&oe=69E3D346",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 14, 2026. May be an image of tofu, stew and text.",
+    "scraped_at_utc": "2026-04-14T08:19:26.269798+00:00"
+  },
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DXGB2eWgR79/",
+    "caption": "오늘 점심은\n제육볶음\n수제김치전\n시원한콩나물국\n상추무침과 김치\n흰쌀밥 입니다~^^♡",
+    "published_at_iso": "2026-04-14T01:48:26.000Z",
+    "published_at_display": "6시간",
+    "like_count": 3,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/671227231_18524832280073374_8557820847164392498_n.webp?_nc_cat=104&ig_cache_key=Mzg3NDc5MjY3MDg4Njk2MDg5Mw%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTQ0MC5zZHIuQzMifQ%3D%3D&_nc_ohc=LsXYaW2mqP4Q7kNvwG9QBHe&_nc_oc=AdqoSDEgthVGvHJ78IU1oxVziTCSJgLYTN5Lo4G8umatQQ22A7n2ZjvQKu1nBFSWklw&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=ix3ryXFJO_0DDFgni6coPw&_nc_ss=7a32e&oh=00_Af2iNtn2JdfU9HscookRbutVVqRN8QTid0fVJj5-D-VxKg&oe=69E3E348",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 13, 2026. May be an image of tofu and text.",
+    "scraped_at_utc": "2026-04-14T08:19:39.724064+00:00"
+  },
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DXEGUbLjji8/",
+    "caption": "오늘 저녁은\n로제크림스파게티\n문어타코야끼\n후르츠샐러드\n크림스프\n김치와 피클\n추가밥 입니다~^^♡",
+    "published_at_iso": "2026-04-13T07:48:59.000Z",
+    "published_at_display": "9시간",
+    "like_count": 2,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/671072700_18524694910073374_4416403350157823203_n.webp?_nc_cat=105&ig_cache_key=Mzg3NDI0OTM3MTI5ODk2OTc4OA%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTQ0MC5zZHIuQzMifQ%3D%3D&_nc_ohc=ipstCjNM1VgQ7kNvwHB4Q2E&_nc_oc=Adpz8-4IEn3aImLeTkZDikg00opdfauYyQSAD1wnvWPWi1qaGSWrrZ9IQW7SqyZ8ou0&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=WMTC4plTfYRU0T_v_gR8hw&_nc_ss=7a32e&oh=00_Af1ZRfKVJA4nyW2TvkvsqgpROzNDzsJtLf9trs1MQ3IXPA&oe=69E3083C",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 13, 2026. May be an image of pasta, spaghetti and text.",
+    "scraped_at_utc": "2026-04-13T17:20:37.910335+00:00"
+  },
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DXDbMyWASWe/",
+    "caption": "오늘 점심은\n치킨마요덮밥\n시원한쥬시쿨\n명엽채볶음\n유부장국\n콘샐러드와 김치\n입니다~^^♡\n좋은 날 보내세요!!",
+    "published_at_iso": "2026-04-13T01:32:13.000Z",
+    "published_at_display": "15시간",
+    "like_count": 5,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/670103122_18524660272073374_2877733876658232813_n.webp?_nc_cat=109&ig_cache_key=Mzg3NDA1OTczMDQxNDU0NDI4Ng%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTA4Ny5zZHIuQzMifQ%3D%3D&_nc_ohc=sOXp8ouOuwsQ7kNvwF0bm1I&_nc_oc=AdqnhMkfvrp7bBMdp9c_zFw2Ge4n45G7c-Q3ZWddfPOCQbEnZ7-OdYqqzQsChgyc9eY&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=qRObE8qbl7agWjeyTU50yA&_nc_ss=7a32e&oh=00_Af0TqrNw2W4whx88ysf5IbZmXHTYGyEyDegI2GNcEL8Psg&oe=69E300B1",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 12, 2026. May be an image of tofu and text.",
+    "scraped_at_utc": "2026-04-13T17:20:51.057605+00:00"
+  },
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DW8XPQ0DgzH/",
+    "caption": "오늘 저녁은\n고구마닭갈비\n동그랑땡전\n고추지무침\n깍두기\n밥과 된장국 입니다^^♡",
+    "published_at_iso": "2026-04-10T07:42:54.000Z",
+    "published_at_display": "3일",
+    "like_count": 2,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/669653608_18524206105073374_6701180008032458134_n.webp?_nc_cat=107&ig_cache_key=Mzg3MjA3MTk4MzU0Njg5NTU1OQ%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTQ0MC5zZHIuQzMifQ%3D%3D&_nc_ohc=rStAIxZytaEQ7kNvwE_GBAx&_nc_oc=Adq49gRSLpmB0YOrUjR_B1t-q6yfK1NIsG_7F5COOU2wOF4rVQQg5QKtlwkoyf8ASXQ&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=_lcLSdDM4CI_Ny1VN5QeDA&_nc_ss=7a32e&oh=00_Af1aYid0X1eju-Of8YeGduPg2F_CGU17V4VhhjE_72msow&oe=69E30B52",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 10, 2026. May be an image of text.",
+    "scraped_at_utc": "2026-04-13T17:21:04.134959+00:00"
+  },
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DW7vVzsgQIH/",
+    "caption": "오늘 점심은\n가쓰오부시볶음우동\n수제야채튀김\n후리가케밥\n계란국\n마카로니샐러드\n김치와 요구르트 입니다~^^♡",
+    "published_at_iso": "2026-04-10T01:54:17.000Z",
+    "published_at_display": "3일",
+    "like_count": 3,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/669717459_18524175112073374_3676587094561846690_n.webp?_nc_cat=107&ig_cache_key=Mzg3MTg5NjUxMTQ1NzU5MTgxNQ%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTQ0MC5zZHIuQzMifQ%3D%3D&_nc_ohc=NImpz9mgzp0Q7kNvwHFerFN&_nc_oc=AdoA8powBdr8Aq2H25cLXV5Q9Qqed9Pz5O_5ec4G5wJgR8cvuIApHRpGSZ5ycVddPKE&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=43VyZc_sCm6Pn04vaK74Uw&_nc_ss=7a32e&oh=00_Af0xhU1X_tBQ5ow1h7RKNa7WrIyVIUfseMhGui50GGYwBA&oe=69E31415",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 09, 2026. May be an image of tofu, rice and text.",
+    "scraped_at_utc": "2026-04-13T17:21:17.213571+00:00"
+  },
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DW59YE2gVUV/",
+    "caption": "오늘 저녁은\n비벼먹는콩나물밥\n잡채어묵&머스타드\n건새우무조림\n메추리알조림\n미역국과 김치 입니다♡",
+    "published_at_iso": "2026-04-09T09:18:27.000Z",
+    "published_at_display": "4일",
+    "like_count": 4,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/669728991_18523968736073374_301843970306639226_n.webp?_nc_cat=102&ig_cache_key=Mzg3MTM5NTI5MDAxNTY4Mzg2MQ%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTQ0MC5zZHIuQzMifQ%3D%3D&_nc_ohc=Bc2eT7omM3YQ7kNvwF66I82&_nc_oc=Adqa8ILh1uFIFr_zqhIkn9gmqhqb9gVEQhyUSDKMFwq12gDVMEQPeypGyMFpBhz8tEI&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=OReriIZsuI1ngSA2x8ThXA&_nc_ss=7a32e&oh=00_Af3_YoV4YRMZpONm5X3Cz_hmjO2bfQsKAj98vEtd1kZBfw&oe=69E2F375",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 09, 2026. May be an image of tofu, seaweed and text.",
+    "scraped_at_utc": "2026-04-13T17:21:30.169377+00:00"
+  },
+  {
+    "username": "incheondae_2gisik",
+    "post_url": "https://www.instagram.com/incheondae_2gisik/p/DW5LmMIgQ07/",
+    "caption": "오늘 점심은\n제육볶음\n상추쌈&쌈장\n군만두구이\n팽이장국과 흰쌀밥\n김치\n시원한 콜라 입니다~~^^♡",
+    "published_at_iso": "2026-04-09T02:03:36.000Z",
+    "published_at_display": "4일",
+    "like_count": 8,
+    "image_url": "https://scontent-ssn1-1.cdninstagram.com/v/t51.82787-15/662018921_18523802263073374_1311891411630225284_n.webp?_nc_cat=108&ig_cache_key=Mzg3MTE3NjM1NzU4MDk2NzIyNw%3D%3D.3-ccb7-5&ccb=7-5&_nc_sid=58cdad&efg=eyJ2ZW5jb2RlX3RhZyI6InhwaWRzLjE0NDB4MTE1Ni5zZHIuQzMifQ%3D%3D&_nc_ohc=p25jgXZLV28Q7kNvwHiUrBm&_nc_oc=AdqmjPtZLkAaz0_KQ-Re3RuoasHFXzipfSYwgTsDVvkwPCKnCBgS7iXa9XX7se8wBb8&_nc_ad=z-m&_nc_cid=0&_nc_zt=23&_nc_ht=scontent-ssn1-1.cdninstagram.com&_nc_gid=pnbKHj0TA0hyfvBqVpyxqQ&_nc_ss=7a32e&oh=00_Af1wBz1He0XhUrXYcP_gwptipqYxCCyeJIVYfSFXJVP-tQ&oe=69E2E929",
+    "image_alt": "Photo by 인천대학교 제2기숙사식당(운영중) on April 08, 2026. May be an image of noodles, rice, chopsticks, dumpling and text.",
+    "scraped_at_utc": "2026-04-13T17:21:43.013525+00:00"
+  }
+]

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/controller/NoticeController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/controller/NoticeController.java
@@ -1,6 +1,5 @@
 package kr.inuappcenterportal.inuportal.domain.notice.controller;
 
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,57 +11,110 @@ import kr.inuappcenterportal.inuportal.domain.notice.dto.DepartmentNoticeListRes
 import kr.inuappcenterportal.inuportal.domain.notice.dto.NoticeListResponseDto;
 import kr.inuappcenterportal.inuportal.domain.notice.enums.Department;
 import kr.inuappcenterportal.inuportal.domain.notice.service.NoticeService;
-import kr.inuappcenterportal.inuportal.domain.post.dto.PostListResponseDto;
+import kr.inuappcenterportal.inuportal.domain.schedule.dto.ScheduleListResponseDoc;
+import kr.inuappcenterportal.inuportal.domain.schedule.dto.ScheduleResponseDto;
+import kr.inuappcenterportal.inuportal.domain.schedule.service.ScheduleService;
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
 import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.io.IOException;
 import java.util.List;
 
 @Slf4j
-@Tag(name="Notices", description = "학교 공지사항 API")
+@Tag(name = "Notices", description = "학교 공지사항 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notices")
 public class NoticeController {
     private final NoticeService noticeService;
+    private final ScheduleService scheduleService;
 
-    @Operation(summary = "모든 공지사항 가져오기",description = "url 파라미터에 카테고리(빈 값일 시 모든 공지사항), 정렬기준(sort) 을 date/공백(최신순), view 둘 중 하나),페이지(공백일 시 1)를 보내주세요")
+    @Operation(summary = "모든 공지사항 가져오기", description = "url 파라미터로 카테고리, 정렬기준, 페이지를 보냅니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200",description = "모든 공지사항 가져오기 성공",content = @Content(schema = @Schema(implementation = NoticeListResponseDto.class))),
-            @ApiResponse(responseCode = "400",description = "정렬의 기준값이 올바르지 않습니다.",content = @Content(schema = @Schema(implementation = ResponseDto.class)))
-
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "모든 공지사항 가져오기 성공",
+                    content = @Content(schema = @Schema(implementation = NoticeListResponseDto.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "정렬 기준값이 올바르지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ResponseDto.class))
+            )
     })
     @GetMapping("")
-    public ResponseEntity<ResponseDto<ListResponseDto<NoticeListResponseDto>>> getAllNotice(@RequestParam(required = false) String category, @RequestParam(required = false,defaultValue = "date") String sort
-    , @RequestParam(required = false,defaultValue = "1") @Min(1) int page){
-        return ResponseEntity.ok(ResponseDto.of(noticeService.getNoticeList(category, sort,page),"모든 공지사항 가져오기 성공"));
+    public ResponseEntity<ResponseDto<ListResponseDto<NoticeListResponseDto>>> getAllNotice(
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false, defaultValue = "date") String sort,
+            @RequestParam(required = false, defaultValue = "1") @Min(1) int page
+    ) {
+        return ResponseEntity.ok(ResponseDto.of(noticeService.getNoticeList(category, sort, page), "모든 공지사항 가져오기 성공"));
     }
 
     @Operation(summary = "상단부 인기 공지 12개 가져오기")
     @ApiResponses({
-            @ApiResponse(responseCode = "200",description = "인기 공지 가져오기 성공",content = @Content(schema = @Schema(implementation = NoticeListResponseDto.class)))
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "인기 공지 가져오기 성공",
+                    content = @Content(schema = @Schema(implementation = NoticeListResponseDto.class))
+            )
     })
     @GetMapping("/top")
-    public ResponseEntity<ResponseDto<List<NoticeListResponseDto>>> getPostForTop( ){
-        return ResponseEntity.ok(ResponseDto.of(noticeService.getTop(),"인기 공지 가져오기 성공"));
+    public ResponseEntity<ResponseDto<List<NoticeListResponseDto>>> getPostForTop() {
+        return ResponseEntity.ok(ResponseDto.of(noticeService.getTop(), "인기 공지 가져오기 성공"));
     }
 
-    @Operation(summary = "학과 별 공지사항 가져오기",description = "url 파라미터에 학과(빈 값 불가), 정렬기준(sort) 을 date/공백(최신순), view 둘 중 하나), 페이지(공백일 시 1)를 보내주세요")
+    @Operation(summary = "학과별 공지사항 가져오기", description = "url 파라미터로 학과, 정렬기준, 페이지를 보냅니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200",description = "학과 별 모든 공지사항 가져오기 성공",content = @Content(schema = @Schema(implementation = DepartmentNoticeListResponse.class))),
-            @ApiResponse(responseCode = "400",description = "정렬의 기준값이 올바르지 않습니다.",content = @Content(schema = @Schema(implementation = ResponseDto.class)))
-
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "학과별 공지사항 가져오기 성공",
+                    content = @Content(schema = @Schema(implementation = DepartmentNoticeListResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "정렬 기준값이 올바르지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ResponseDto.class))
+            )
     })
     @GetMapping("/department")
     public ResponseEntity<ResponseDto<ListResponseDto<DepartmentNoticeListResponse>>> getDepartmentNotices(
             @RequestParam Department department,
-            @RequestParam(required = false,defaultValue = "date") String sort,
-            @RequestParam(required = false,defaultValue = "1") @Min(1) int page) {
-        return ResponseEntity.ok(ResponseDto.of(noticeService.getDepartmentNotices(department, sort, page),"해당 학과 모든 공지사항 가져오기 성공"));
+            @RequestParam(required = false, defaultValue = "date") String sort,
+            @RequestParam(required = false, defaultValue = "1") @Min(1) int page
+    ) {
+        return ResponseEntity.ok(
+                ResponseDto.of(
+                        noticeService.getDepartmentNotices(department, sort, page),
+                        "해당 학과 모든 공지사항 가져오기 성공"
+                )
+        );
+    }
+
+    @Operation(summary = "학과 공지 연결 일정 조회", description = "학과 공지 id로 연결된 일정 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "학과 공지 연결 일정 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ScheduleListResponseDoc.class))
+            )
+    })
+    @GetMapping("/department/{departmentNoticeId}/schedules")
+    public ResponseEntity<ResponseDto<List<ScheduleResponseDto>>> getSchedulesByDepartmentNoticeId(
+            @PathVariable Long departmentNoticeId
+    ) {
+        return ResponseEntity.ok(
+                ResponseDto.of(
+                        scheduleService.getSchedulesByDepartmentNoticeId(departmentNoticeId),
+                        "학과 공지 연결 일정 조회 성공"
+                )
+        );
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/dto/DepartmentNoticeListResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/dto/DepartmentNoticeListResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import kr.inuappcenterportal.inuportal.domain.notice.enums.Department;
 import kr.inuappcenterportal.inuportal.domain.notice.model.DepartmentNotice;
 
-@Schema(description = "각 학과 별 공지사항 리스트 응답")
+@Schema(description = "학과 공지사항 목록 응답")
 public record DepartmentNoticeListResponse(
 
         @Schema(description = "공지사항 데이터베이스 id 값", example = "1")
@@ -13,7 +13,7 @@ public record DepartmentNoticeListResponse(
         @Schema(description = "제목", example = "2025학년도 2학기 전공심화트랙 이수 신청 안내")
         String title,
 
-        @Schema(description = "학과", example = "컴퓨터공학과")
+        @Schema(description = "학과", example = "컴퓨터공학부")
         Department department,
 
         @Schema(description = "작성일", example = "2025.08.06")
@@ -23,17 +23,21 @@ public record DepartmentNoticeListResponse(
         Long view,
 
         @Schema(description = "링크 url", example = "https://example.com")
-        String url
+        String url,
+
+        @Schema(description = "연결된 일정 존재 여부", example = "true")
+        boolean hasSchedules
 
 ) {
-    public static DepartmentNoticeListResponse of (DepartmentNotice departmentNotice) {
+    public static DepartmentNoticeListResponse of(DepartmentNotice departmentNotice, boolean hasSchedules) {
         return new DepartmentNoticeListResponse(
                 departmentNotice.getId(),
                 departmentNotice.getTitle(),
                 departmentNotice.getDepartment(),
                 departmentNotice.getCreateDate(),
                 departmentNotice.getView(),
-                departmentNotice.getUrl()
+                departmentNotice.getUrl(),
+                hasSchedules
         );
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
@@ -13,6 +13,8 @@ import kr.inuappcenterportal.inuportal.domain.notice.model.Notice;
 import kr.inuappcenterportal.inuportal.domain.notice.repository.DepartmentCrawlerStateRepository;
 import kr.inuappcenterportal.inuportal.domain.notice.repository.DepartmentNoticeRepository;
 import kr.inuappcenterportal.inuportal.domain.notice.repository.NoticeRepository;
+import kr.inuappcenterportal.inuportal.domain.schedule.model.Schedule;
+import kr.inuappcenterportal.inuportal.domain.schedule.repository.ScheduleRepository;
 import kr.inuappcenterportal.inuportal.global.config.DepartmentCrawlConfig;
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
@@ -49,6 +51,7 @@ import java.util.HexFormat;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -93,6 +96,7 @@ public class NoticeService {
     private final CacheManager cacheManager;
     private final KeywordService keywordService;
     private final ObjectMapper objectMapper;
+    private final ScheduleRepository scheduleRepository;
 
     @Qualifier("localCacheManager")
     private final CacheManager localCacheManager;
@@ -106,7 +110,8 @@ public class NoticeService {
             DepartmentNoticeRepository departmentNoticeRepository,
             DepartmentCrawlerStateRepository departmentCrawlerStateRepository,
             KeywordService keywordService,
-            ObjectMapper objectMapper
+            ObjectMapper objectMapper,
+            ScheduleRepository scheduleRepository
     ) {
         this.noticeRepository = noticeRepository;
         this.departmentNoticeRepository = departmentNoticeRepository;
@@ -115,6 +120,7 @@ public class NoticeService {
         this.departmentCrawlerStateRepository = departmentCrawlerStateRepository;
         this.keywordService = keywordService;
         this.objectMapper = objectMapper;
+        this.scheduleRepository = scheduleRepository;
     }
 
     @Scheduled(cron = "0 0/30 * * * *")
@@ -839,12 +845,38 @@ public class NoticeService {
     public ListResponseDto<DepartmentNoticeListResponse> getDepartmentNotices(Department department, String sort, int page) {
         Pageable pageable = PageRequest.of(page > 0 ? --page : page, 8, sort(sort));
         Page<DepartmentNotice> departmentNotices = departmentNoticeRepository.findAllByDepartment(department, pageable);
+        Map<Long, Boolean> hasSchedulesMap = loadHasSchedulesMap(departmentNotices.getContent());
 
         return ListResponseDto.of(
                 departmentNotices.getTotalPages(),
                 departmentNotices.getTotalElements(),
-                departmentNotices.getContent().stream().map(DepartmentNoticeListResponse::of).collect(Collectors.toList())
+                departmentNotices.getContent().stream()
+                        .map(notice -> DepartmentNoticeListResponse.of(
+                                notice,
+                                hasSchedulesMap.getOrDefault(notice.getId(), false)
+                        ))
+                        .collect(Collectors.toList())
         );
+    }
+
+    private Map<Long, Boolean> loadHasSchedulesMap(List<DepartmentNotice> notices) {
+        List<Long> noticeIds = notices.stream()
+                .map(DepartmentNotice::getId)
+                .toList();
+
+        if (noticeIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return scheduleRepository.findAllBySourceNoticeIdInAndAiGeneratedTrue(noticeIds).stream()
+                .filter(schedule -> schedule.getSourceNoticeId() != null)
+                .collect(Collectors.groupingBy(
+                        Schedule::getSourceNoticeId,
+                        Collectors.collectingAndThen(
+                                Collectors.counting(),
+                                count -> count > 0
+                        )
+                ));
     }
 
     private Connection connect(String url) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/controller/ScheduleController.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,7 +31,7 @@ import java.util.List;
 public class ScheduleController {
     private final ScheduleService scheduleService;
 
-    @Operation(summary = "학사일정 가져오기", description = "url 파라미터로 year, month를 보내주세요.")
+    @Operation(summary = "학사일정 가져오기", description = "url 파라미터로 year, month를 보내주세요")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -67,6 +68,23 @@ public class ScheduleController {
                         scheduleService.getMyDepartmentScheduleByMonth(member, year, month),
                         "내 학과 일정 가져오기 성공"
                 )
+        );
+    }
+
+    @Operation(summary = "일정 단건 조회", description = "scheduleId로 일정 1건을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "일정 단건 조회 성공",
+                    content = @Content(schema = @Schema(implementation = ScheduleResponseDto.class))
+            )
+    })
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ResponseDto<ScheduleResponseDto>> getSchedule(
+            @PathVariable Long scheduleId
+    ) {
+        return ResponseEntity.ok(
+                ResponseDto.of(scheduleService.getSchedule(scheduleId), "일정 단건 조회 성공")
         );
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/dto/ScheduleResponseDto.java
@@ -14,6 +14,9 @@ import java.time.format.DateTimeFormatter;
 @NoArgsConstructor
 public class ScheduleResponseDto {
 
+    @Schema(description = "일정 id", example = "101")
+    private Long id;
+
     @Schema(description = "제목", example = "수강신청")
     private String title;
 
@@ -43,6 +46,7 @@ public class ScheduleResponseDto {
 
     @Builder
     private ScheduleResponseDto(
+            Long id,
             String start,
             String end,
             String title,
@@ -53,6 +57,7 @@ public class ScheduleResponseDto {
             String sourceNoticeTitle,
             String url
     ) {
+        this.id = id;
         this.start = start;
         this.end = end;
         this.title = title;
@@ -70,6 +75,7 @@ public class ScheduleResponseDto {
 
     public static ScheduleResponseDto of(Schedule schedule, DepartmentNotice sourceNotice) {
         return ScheduleResponseDto.builder()
+                .id(schedule.getId())
                 .start(schedule.getStartDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .end(schedule.getEndDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
                 .title(schedule.getContent())

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/repository/ScheduleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
@@ -43,6 +44,10 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             @Param("monthStart") LocalDate monthStart,
             @Param("monthEnd") LocalDate monthEnd
     );
+
+    List<Schedule> findAllBySourceNoticeIdAndAiGeneratedTrueOrderByStartDateAscIdAsc(Long sourceNoticeId);
+
+    List<Schedule> findAllBySourceNoticeIdInAndAiGeneratedTrue(Collection<Long> sourceNoticeIds);
 
     @Query("SELECT COALESCE(MAX(s.id), 0) FROM Schedule s")
     Long findMaxId();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/service/ScheduleService.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -27,6 +28,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -164,6 +167,29 @@ public class ScheduleService {
                         schedule,
                         sourceNoticeMap.get(schedule.getSourceNoticeId())
                 ))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ScheduleResponseDto getSchedule(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "존재하지 않는 일정입니다."));
+
+        DepartmentNotice sourceNotice = null;
+        if (schedule.getSourceNoticeId() != null) {
+            sourceNotice = departmentNoticeRepository.findById(schedule.getSourceNoticeId()).orElse(null);
+        }
+
+        return ScheduleResponseDto.of(schedule, sourceNotice);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ScheduleResponseDto> getSchedulesByDepartmentNoticeId(Long departmentNoticeId) {
+        DepartmentNotice departmentNotice = departmentNoticeRepository.findById(departmentNoticeId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "존재하지 않는 학과 공지입니다."));
+
+        return scheduleRepository.findAllBySourceNoticeIdAndAiGeneratedTrueOrderByStartDateAscIdAsc(departmentNoticeId).stream()
+                .map(schedule -> ScheduleResponseDto.of(schedule, departmentNotice))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 📎 관련 이슈

- closed #166 

## 📄 설명

- 학과 공지사항의 내용도 크롤링 대상에 추가.
- 야간 시간에 AI서버에 공지사항 내용을 보내서 일정 정보를 받아와 저장
- 캘린더에 본인 학과 일정 정보 추가
- 학과 공지 목록 리턴 시 연결된 공지사항 보유 여부 포함
- 연결된 공지사항에서 추출된 일정 정보 목록 리턴 API

## 🤔 추후 작업 사항

- ex) 성능 개선 필요