### PR TITLE
feat: 스케줄러 분산 락(ShedLock) 도입 및 Prometheus 메트릭 가시화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0'
+
 //    implementation 'io.github.bonigarcia:webdrivermanager:5.6.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 //    implementation 'io.github.bonigarcia:webdrivermanager:5.6.3'
 }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/cafeteria/service/CafeteriaService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/cafeteria/service/CafeteriaService.java
@@ -5,6 +5,7 @@ import jakarta.transaction.Transactional;
 import kr.inuappcenterportal.inuportal.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -35,6 +36,11 @@ public class CafeteriaService {
     }
 
     @Scheduled(cron = "0 10 0 ? * MON-SAT")
+    @SchedulerLock(
+            name = "cafeteria-menu",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M"
+    )
     @Transactional
     public void jobCafeteria() throws InterruptedException {
         crawlCafeteria();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/cafeteria/service/instagram/SecondDormitoryInstagramCrawlService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/cafeteria/service/instagram/SecondDormitoryInstagramCrawlService.java
@@ -7,6 +7,7 @@ import kr.inuappcenterportal.inuportal.domain.featureflag.service.FeatureFlagSer
 import kr.inuappcenterportal.inuportal.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -52,6 +53,11 @@ public class SecondDormitoryInstagramCrawlService {
             cron = "${app.cafeteria.instagram.second-dormitory.lunch-retry-cron:0 */15 10-11 * * *}",
             zone = "${app.cafeteria.instagram.second-dormitory.zone:Asia/Seoul}"
     )
+    @SchedulerLock(
+            name = "cafeteria-2dorm-insta",
+            lockAtMostFor = "PT15M",
+            lockAtLeastFor = "PT1M"
+    )
     public void refreshLunchRetryWindow() {
         if (!isRetryExecutionTime(MealWindow.LUNCH)) {
             return;
@@ -62,6 +68,11 @@ public class SecondDormitoryInstagramCrawlService {
     @Scheduled(
             cron = "${app.cafeteria.instagram.second-dormitory.dinner-retry-cron:0 */15 17-18 * * *}",
             zone = "${app.cafeteria.instagram.second-dormitory.zone:Asia/Seoul}"
+    )
+    @SchedulerLock(
+            name = "cafeteria-2dorm-insta",
+            lockAtMostFor = "PT15M",
+            lockAtLeastFor = "PT1M"
     )
     public void refreshDinnerRetryWindow() {
         if (!isRetryExecutionTime(MealWindow.DINNER)) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/config/StompHandler.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/config/StompHandler.java
@@ -1,5 +1,7 @@
 package kr.inuappcenterportal.inuportal.domain.chat.config;
 
+import kr.inuappcenterportal.inuportal.domain.chat.service.ChatRoomService;
+import java.util.Map;
 import kr.inuappcenterportal.inuportal.global.config.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,30 +24,86 @@ import org.springframework.stereotype.Component;
 public class StompHandler implements ChannelInterceptor {
 
     private final TokenProvider tokenProvider;
+    private final ChatRoomService chatRoomService;
+    private final kr.inuappcenterportal.inuportal.domain.chat.repository.ChatRoomMemberRepository chatRoomMemberRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-            String token = accessor.getFirstNativeHeader("Auth");
+        if (accessor != null) {
+            if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                String token = accessor.getFirstNativeHeader("Auth");
 
-            if (token != null && token.startsWith("Bearer ")) {
-                token = token.substring(7);
+                if (token != null && token.startsWith("Bearer ")) {
+                    token = token.substring(7);
+                }
+
+                if (token != null && tokenProvider.validateToken(token)) {
+                    Authentication authentication = tokenProvider.getAuthentication(token);
+                    accessor.setUser(authentication);
+                    log.info("웹소켓 연결 성공: 사용자={}", authentication.getName());
+                } else {
+                    log.error("웹소켓 인증 실패: 유효하지 않은 토큰이거나 인증 헤더가 누락되었습니다. 토큰={}", token);
+                    throw new AccessDeniedException("유효하지 않은 토큰입니다.");
+                }
+            }
+            
+            // 2. SUBSCRIBE 감지하여 방 검증 및 Redis 자동 등록
+            else if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+                String destination = accessor.getDestination();
+                if (destination != null && destination.startsWith("/sub/room/")) {
+                    Long roomId = extractRoomId(destination);
+                    Long memberId = getMemberId(accessor);
+
+                    // 해당 채팅방 참여자인지 검증 (JOINED 상태여야 함)
+                    boolean isMember = chatRoomMemberRepository.existsByChatRoomIdAndMemberIdAndStatus(roomId, memberId, kr.inuappcenterportal.inuportal.domain.chat.enums.ChatMemberStatus.JOINED);
+                    if (!isMember) {
+                        log.warn("[STOMP] 권한 없는 구독 시도 차단: Member {}, Room {}", memberId, roomId);
+                        throw new AccessDeniedException("해당 채팅방에 참여할 권한이 없습니다.");
+                    }
+
+                    // 세션 속성에 roomId, memberId 저장 (Disconnect/Unsubscribe 시 자동 해제 목적)
+                    Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+                    if (sessionAttributes != null) {
+                        sessionAttributes.put("roomId", roomId);
+                        sessionAttributes.put("memberId", memberId);
+                    }
+
+                    // Redis 및 채팅방 진입 자동 활성화 (안 읽음 처리 및 브로드캐스트 포함)
+                    chatRoomService.enterChatRoom(roomId, memberId);
+                    log.info("[STOMP] 구독 감지로 접속 활성화: Member {} -> Room {}", memberId, roomId);
+                }
             }
 
-            if (token != null && tokenProvider.validateToken(token)) {
-                Authentication authentication = tokenProvider.getAuthentication(token);
-                accessor.setUser(authentication);
-                log.info("웹소켓 연결 성공: 사용자={}", authentication.getName());
-            } else {
-                log.error("웹소켓 인증 실패: 유효하지 않은 토큰이거나 인증 헤더가 누락되었습니다. 토큰={}", token);
-                throw new AccessDeniedException("유효하지 않은 토큰입니다.");
+            // 3. UNSUBSCRIBE 감지하여 Redis 자동 해제
+            else if (StompCommand.UNSUBSCRIBE.equals(accessor.getCommand())) {
+                Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+                if (sessionAttributes != null && sessionAttributes.containsKey("roomId") && sessionAttributes.containsKey("memberId")) {
+                    Long roomId = (Long) sessionAttributes.get("roomId");
+                    Long memberId = (Long) sessionAttributes.get("memberId");
+
+                    chatRoomService.exitChatRoom(roomId, memberId);
+                    log.info("[STOMP] 구독 해제 감지로 접속 비활성화: Member {} -> Room {}", memberId, roomId);
+                }
             }
         }
 
-        // TODO: SUBSCRIBE 명령어일 경우, 해당 채팅방의 실제 참여자인지 DB/Redis를 통해 확인하는 로직 추가 가능
-        
         return message;
+    }
+
+    private Long extractRoomId(String destination) {
+        try {
+            return Long.parseLong(destination.replace("/sub/room/", ""));
+        } catch (NumberFormatException e) {
+            throw new AccessDeniedException("올바르지 않은 구독 경로입니다.");
+        }
+    }
+
+    private Long getMemberId(StompHeaderAccessor accessor) {
+        if (accessor.getUser() != null) {
+            return Long.parseLong(accessor.getUser().getName());
+        }
+        throw new AccessDeniedException("인증 정보가 유효하지 않습니다.");
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/config/StompHandler.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/config/StompHandler.java
@@ -1,5 +1,7 @@
 package kr.inuappcenterportal.inuportal.domain.chat.config;
 
+import org.springframework.context.annotation.Lazy;
+import org.springframework.beans.factory.annotation.Autowired;
 import kr.inuappcenterportal.inuportal.domain.chat.service.ChatRoomService;
 import java.util.Map;
 import kr.inuappcenterportal.inuportal.global.config.TokenProvider;
@@ -24,7 +26,11 @@ import org.springframework.stereotype.Component;
 public class StompHandler implements ChannelInterceptor {
 
     private final TokenProvider tokenProvider;
-    private final ChatRoomService chatRoomService;
+    
+    @Autowired
+    @Lazy
+    private ChatRoomService chatRoomService;
+    
     private final kr.inuappcenterportal.inuportal.domain.chat.repository.ChatRoomMemberRepository chatRoomMemberRepository;
 
     @Override

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/controller/ChatController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/controller/ChatController.java
@@ -42,22 +42,4 @@ public class ChatController {
         Long memberId = Long.parseLong(authentication.getName());
         chatRoomService.sendMessage(messageDto, memberId);
     }
-    @MessageMapping("/enter")
-    public void enter(ChatMessageRequestDto messageDto, Authentication authentication, SimpMessageHeaderAccessor headerAccessor) {
-        Long memberId = Long.parseLong(authentication.getName());
-        
-        // 세션 속성에 현재 채팅방 ID 저장 (연결 끊김 시 자동 처리를 위함)
-        if (headerAccessor.getSessionAttributes() != null) {
-            headerAccessor.getSessionAttributes().put("roomId", messageDto.getRoomId());
-            headerAccessor.getSessionAttributes().put("memberId", memberId);
-        }
-        
-        chatRoomService.enterChatRoom(messageDto.getRoomId(), memberId);
-    }
-
-    @MessageMapping("/leave")
-    public void leave(ChatMessageRequestDto messageDto, Authentication authentication) {
-        Long memberId = Long.parseLong(authentication.getName());
-        chatRoomService.exitChatRoom(messageDto.getRoomId(), memberId);
-    }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/repository/ChatRoomMemberRepository.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, Long> {
     Optional<ChatRoomMember> findByChatRoomAndMember(ChatRoom chatRoom, Member member);
     boolean existsByChatRoomAndMember(ChatRoom chatRoom, Member member);
+    boolean existsByChatRoomIdAndMemberIdAndStatus(Long chatRoomId, Long memberId, ChatMemberStatus status);
     int countByChatRoom(ChatRoom chatRoom);
     List<ChatRoomMember> findAllByMemberAndStatus(Member member, ChatMemberStatus status);
     List<ChatRoomMember> findAllByChatRoomAndStatus(ChatRoom chatRoom, ChatMemberStatus status);

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/service/ChatRoomService.java
@@ -1000,49 +1000,59 @@ public class ChatRoomService {
             return;
         }
 
-        // 3. 일반 알림(소리/진동) 대상과 무음 알림(알림창에만 표시) 대상으로 분할
-        List<Long> normalMemberIds = eligibleMembers.stream()
-                .filter(m -> m.getPushEnabled() != null ? m.getPushEnabled() : true)
-                .map(m -> m.getMember().getId())
-                .toList();
 
-        List<Long> mutedMemberIds = eligibleMembers.stream()
-                .filter(m -> m.getPushEnabled() != null && !m.getPushEnabled())
-                .map(m -> m.getMember().getId())
-                .toList();
+        // 3. 커스텀 닉네임(친구 별칭) 적용 및 무음 알림 여부에 따른 분할 그룹 구성
+        Map<String, List<Long>> pushGroup = new HashMap<>();
 
-        // 4. 알림 제목 및 내용 구성
-        String title;
-        String body;
-
-        if (room.isOfficial()) {
-            title = "INTIP 운영자";
-            body = content;
-        } else if (room.getType() == ChatRoomType.PERSONAL) {
-            if (joinedMembers.size() == 2) {
-                // 1:1 채팅
-                title = senderNickname;
-                body = content;
-            } else {
-                // 그룹 채팅
-                title = (room.getTitle() == null || room.getTitle().isEmpty()) ? "그룹 채팅" : room.getTitle();
-                body = senderNickname + ": " + content;
+        for (ChatRoomMember m : eligibleMembers) {
+            String resolvedName = senderNickname;
+            if (!room.isAnonymous() && !room.isOfficial()) {
+                String alias = friendRepository.findByRequesterAndReceiver(m.getMember(), sender)
+                        .filter(f -> f.getStatus() == FriendStatus.ACCEPTED)
+                        .map(kr.inuappcenterportal.inuportal.domain.member.model.Friend::getRequesterAlias)
+                        .orElseGet(() -> friendRepository.findByRequesterAndReceiver(sender, m.getMember())
+                                .filter(f -> f.getStatus() == FriendStatus.ACCEPTED)
+                                .map(kr.inuappcenterportal.inuportal.domain.member.model.Friend::getReceiverAlias)
+                                .orElse(null));
+                if (alias != null && !alias.trim().isEmpty()) {
+                    resolvedName = alias;
+                }
             }
-        } else {
-            // 오픈 채팅 (익명 포함)
-            title = room.getTitle();
-            body = senderNickname + ": " + content;
+
+            String title;
+            String body;
+
+            if (room.isOfficial()) {
+                title = "INTIP 운영자";
+                body = content;
+            } else if (room.getType() == ChatRoomType.PERSONAL) {
+                if (joinedMembers.size() == 2) {
+                    title = resolvedName;
+                    body = content;
+                } else {
+                    title = (room.getTitle() == null || room.getTitle().isEmpty()) ? "그룹 채팅" : room.getTitle();
+                    body = resolvedName + ": " + content;
+                }
+            } else {
+                title = room.getTitle();
+                body = resolvedName + ": " + content;
+            }
+
+            boolean isMuted = m.getPushEnabled() != null && !m.getPushEnabled();
+            String key = title + "|||" + body + "|||" + isMuted;
+            pushGroup.computeIfAbsent(key, k -> new ArrayList<>()).add(m.getMember().getId());
         }
 
-        // 5. 알림 전송 (비동기 처리됨)
-        // 일반 사용자들에게 발송 (소리/진동 있음)
-        if (!normalMemberIds.isEmpty()) {
-            fcmAsyncService.sendAsyncChatNotification(normalMemberIds, title, body, room.getId(), false);
-        }
-        // 무음 설정 사용자들에게 발송 (소리/진동 없음, 알림창에만 노출)
-        if (!mutedMemberIds.isEmpty()) {
-            fcmAsyncService.sendAsyncChatNotification(mutedMemberIds, title, body, room.getId(), true);
-        }
+        // 4. 그룹별 비동기 푸시 발송
+        pushGroup.forEach((key, memberIds) -> {
+            String[] parts = key.split("\\|\\|\\|");
+            if (parts.length >= 3) {
+                String title = parts[0];
+                String body = parts[1];
+                boolean isMuted = Boolean.parseBoolean(parts[2]);
+                fcmAsyncService.sendAsyncChatNotification(memberIds, title, body, room.getId(), isMuted);
+            }
+        });
     }
 
     private ChatMessageResponseDto convertToDto(ChatMessage message) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/chat/service/ChatRoomService.java
@@ -986,23 +986,32 @@ public class ChatRoomService {
         // 1. 현재 방에 접속 중인 사용자 ID 목록 가져오기
         Set<String> activeUserIds = chatRedisService.getRoomUserIds(room.getId());
 
-        // 2. 알림을 받을 멤버 필터링 (참여 중인 멤버 - 나 - 현재 접속자)
+        // 2. 알림 대상 멤버 전체 필터링 (참여 중인 멤버 중 발신자 제외, 현재 접속자 제외, 멤버 전역 알림 허용 여부 확인)
         List<ChatRoomMember> joinedMembers = chatRoomMemberRepository.findAllByChatRoomAndStatus(room,
                 ChatMemberStatus.JOINED);
-        List<Long> targetMemberIds = joinedMembers.stream()
-                .filter(m -> m.getPushEnabled() != null ? m.getPushEnabled() : true)
-                .map(ChatRoomMember::getMember)
-                .filter(m -> m.getChatPushEnabled() != null ? m.getChatPushEnabled() : true)
-                .filter(m -> !m.getId().equals(sender.getId())) // 발신자 제외
-                .filter(m -> !activeUserIds.contains(String.valueOf(m.getId()))) // 현재 접속자 제외
-                .map(Member::getId)
+
+        List<ChatRoomMember> eligibleMembers = joinedMembers.stream()
+                .filter(m -> m.getMember().getChatPushEnabled() != null ? m.getMember().getChatPushEnabled() : true)
+                .filter(m -> !m.getMember().getId().equals(sender.getId())) // 발신자 제외
+                .filter(m -> !activeUserIds.contains(String.valueOf(m.getMember().getId()))) // 현재 접속자 제외
                 .toList();
 
-        if (targetMemberIds.isEmpty()) {
+        if (eligibleMembers.isEmpty()) {
             return;
         }
 
-        // 3. 알림 제목 및 내용 구성
+        // 3. 일반 알림(소리/진동) 대상과 무음 알림(알림창에만 표시) 대상으로 분할
+        List<Long> normalMemberIds = eligibleMembers.stream()
+                .filter(m -> m.getPushEnabled() != null ? m.getPushEnabled() : true)
+                .map(m -> m.getMember().getId())
+                .toList();
+
+        List<Long> mutedMemberIds = eligibleMembers.stream()
+                .filter(m -> m.getPushEnabled() != null && !m.getPushEnabled())
+                .map(m -> m.getMember().getId())
+                .toList();
+
+        // 4. 알림 제목 및 내용 구성
         String title;
         String body;
 
@@ -1025,11 +1034,15 @@ public class ChatRoomService {
             body = senderNickname + ": " + content;
         }
 
-        // 4. 알림 전송 (비동기 처리됨)
-        // 채팅 알림도 이력에 남기기 위해 sendToMembers (또는 이력을 남기지 않으려면 sendUntrackedNotification)
-        // 사용 가능
-        // 사용자가 알림 이력 조회를 원하므로 sendKeywordNotice 스타일의 배치를 활용하거나 간단한 래퍼를 사용
-        fcmAsyncService.sendAsyncUntrackedNotification(targetMemberIds, title, body);
+        // 5. 알림 전송 (비동기 처리됨)
+        // 일반 사용자들에게 발송 (소리/진동 있음)
+        if (!normalMemberIds.isEmpty()) {
+            fcmAsyncService.sendAsyncChatNotification(normalMemberIds, title, body, room.getId(), false);
+        }
+        // 무음 설정 사용자들에게 발송 (소리/진동 없음, 알림창에만 노출)
+        if (!mutedMemberIds.isEmpty()) {
+            fcmAsyncService.sendAsyncChatNotification(mutedMemberIds, title, body, room.getId(), true);
+        }
     }
 
     private ChatMessageResponseDto convertToDto(ChatMessage message) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/directory/service/CollegeOfficeContactService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/directory/service/CollegeOfficeContactService.java
@@ -7,6 +7,7 @@ import kr.inuappcenterportal.inuportal.domain.directory.repository.CollegeOffice
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.data.domain.Page;
@@ -33,6 +34,11 @@ public class CollegeOfficeContactService {
     private final DirectoryPersistenceService directoryPersistenceService;
 
     @Scheduled(cron = "0 20 4 * * SAT")
+    @SchedulerLock(
+            name = "directory-college-office",
+            lockAtMostFor = "PT30M",
+            lockAtLeastFor = "PT5M"
+    )
     public void scheduledSync() {
         try {
             CollegeOfficeContactSyncResponse result = sync();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/directory/service/DirectoryService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/directory/service/DirectoryService.java
@@ -11,6 +11,7 @@ import kr.inuappcenterportal.inuportal.domain.directory.repository.DirectorySour
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -48,6 +49,11 @@ public class DirectoryService {
     private final List<DirectorySourceEntryAdapter> sourceEntryAdapters;
 
     @Scheduled(cron = "0 0 4 * * SAT")
+    @SchedulerLock(
+            name = "directory",
+            lockAtMostFor = "PT30M",
+            lockAtLeastFor = "PT5M"
+    )
     public void scheduledSync() {
         try {
             DirectorySyncResponse result = syncAllCategories();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/directory/service/DirectorySourceService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/directory/service/DirectorySourceService.java
@@ -9,6 +9,7 @@ import kr.inuappcenterportal.inuportal.domain.directory.repository.DirectorySour
 import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -39,6 +40,11 @@ public class DirectorySourceService {
     private final DirectoryPersistenceService directoryPersistenceService;
 
     @Scheduled(cron = "0 15 4 * * SAT")
+    @SchedulerLock(
+            name = "directory-source",
+            lockAtMostFor = "PT30M",
+            lockAtLeastFor = "PT5M"
+    )
     public void scheduledSync() {
         try {
             DirectorySourceSyncResponse result = syncInventoryCategories();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/res/NotificationResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/res/NotificationResponse.java
@@ -25,11 +25,14 @@ public record NotificationResponse(
         FcmMessageType type,
 
         @Schema(description = "알림 생성 시간")
-        LocalDateTime createDate // LocalDate 대신 LocalDateTime 사용
+        LocalDateTime createDate, // LocalDate 대신 LocalDateTime 사용
+
+        @Schema(description = "이동 대상 Id (noticeId, friendId 등)")
+        Long targetId
 
 ) {
     public static NotificationResponse from(MemberFcmMessage memberFcmMessage, FcmMessage fcmMessage) {
         return new NotificationResponse(fcmMessage.getId(), memberFcmMessage.getMemberId(),
-                fcmMessage.getTitle(), fcmMessage.getBody(), memberFcmMessage.getFcmMessageType(), memberFcmMessage.getCreateDate());
+                fcmMessage.getTitle(), fcmMessage.getBody(), memberFcmMessage.getFcmMessageType(), memberFcmMessage.getCreateDate(), fcmMessage.getTargetId());
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/model/FcmMessage.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/model/FcmMessage.java
@@ -47,9 +47,12 @@ public class FcmMessage extends BaseTimeEntity {
     @Column(name = "send_status", nullable = false, length = 32)
     private FcmSendStatus sendStatus = FcmSendStatus.PENDING;
 
+    @Column(name = "target_id")
+    private Long targetId;
+
     @Builder
     public FcmMessage(String title, String body, boolean isAdminMessage, int sendCount,
-                      int failureCount, int targetCount, FcmSendStatus sendStatus) {
+                      int failureCount, int targetCount, FcmSendStatus sendStatus, Long targetId) {
         this.title = title;
         this.body = body;
         this.adminMessage = isAdminMessage;
@@ -57,6 +60,7 @@ public class FcmMessage extends BaseTimeEntity {
         this.failureCount = Math.max(failureCount, 0);
         this.targetCount = Math.max(targetCount, 0);
         this.sendStatus = sendStatus == null ? FcmSendStatus.PENDING : sendStatus;
+        this.targetId = targetId;
     }
 
     public void markPending(int targetCount) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
@@ -16,13 +16,13 @@ public class FcmAsyncService {
 
     @Async("messageExecutor")
     public void sendAsyncKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType fcmMessageType) {
-        Long fcmMessageId = fcmService.prepareKeywordNotice(tokenAndMemberId, title, body, fcmMessageType);
+        Long fcmMessageId = fcmService.prepareKeywordNotice(tokenAndMemberId, title, body, fcmMessageType, null);
         fcmService.dispatchKeywordNotice(fcmMessageId, tokenAndMemberId, title, body, fcmMessageType, null);
     }
 
     @Async("messageExecutor")
     public void sendAsyncKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType fcmMessageType, Long targetId) {
-        Long fcmMessageId = fcmService.prepareKeywordNotice(tokenAndMemberId, title, body, fcmMessageType);
+        Long fcmMessageId = fcmService.prepareKeywordNotice(tokenAndMemberId, title, body, fcmMessageType, targetId);
         fcmService.dispatchKeywordNotice(fcmMessageId, tokenAndMemberId, title, body, fcmMessageType, targetId);
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
@@ -17,20 +17,29 @@ public class FcmAsyncService {
     @Async("messageExecutor")
     public void sendAsyncKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType fcmMessageType) {
         Long fcmMessageId = fcmService.prepareKeywordNotice(tokenAndMemberId, title, body, fcmMessageType);
-        fcmService.dispatchKeywordNotice(fcmMessageId, tokenAndMemberId, title, body);
+        fcmService.dispatchKeywordNotice(fcmMessageId, tokenAndMemberId, title, body, fcmMessageType, null);
+    }
+
+    @Async("messageExecutor")
+    public void sendAsyncKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType fcmMessageType, Long targetId) {
+        Long fcmMessageId = fcmService.prepareKeywordNotice(tokenAndMemberId, title, body, fcmMessageType);
+        fcmService.dispatchKeywordNotice(fcmMessageId, tokenAndMemberId, title, body, fcmMessageType, targetId);
     }
 
     @Async("messageExecutor")
     public void sendAsyncToMembers(AdminNotificationDispatch dispatch) {
-        if (!dispatch.hasTarget() && !dispatch.hasMemberTarget()) {
-            return;
-        }
         fcmService.sendToMembers(dispatch);
     }
 
     @Async("messageExecutor")
     public void sendAsyncTrackedNotification(List<Long> memberIds, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType type) {
-        FcmService.TrackedNotificationDispatch dispatch = fcmService.prepareTrackedNotification(memberIds, title, body, type);
+        FcmService.TrackedNotificationDispatch dispatch = fcmService.prepareTrackedNotification(memberIds, title, body, type, null);
+        fcmService.dispatchTrackedNotification(dispatch);
+    }
+
+    @Async("messageExecutor")
+    public void sendAsyncTrackedNotification(List<Long> memberIds, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType type, Long targetId) {
+        FcmService.TrackedNotificationDispatch dispatch = fcmService.prepareTrackedNotification(memberIds, title, body, type, targetId);
         fcmService.dispatchTrackedNotification(dispatch);
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
@@ -38,4 +38,9 @@ public class FcmAsyncService {
     public void sendAsyncUntrackedNotification(List<Long> memberIds, String title, String body) {
         fcmService.sendUntrackedNotification(memberIds, title, body);
     }
+
+    @Async("messageExecutor")
+    public void sendAsyncChatNotification(List<Long> memberIds, String title, String body, Long chatRoomId, boolean isMuted) {
+        fcmService.sendChatNotification(memberIds, title, body, chatRoomId, isMuted);
+    }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -104,7 +104,7 @@ public class FcmService {
             return;
         }
 
-        MulticastMessage message = createMulticastMessage(target, title, body);
+        MulticastMessage message = createMulticastMessage(target, title, body, null, null);
         try {
             BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
             fcmMessage.updateDeliveryResult(response.getSuccessCount(), response.getFailureCount());
@@ -164,6 +164,7 @@ public class FcmService {
                                 .setBody(title)
                                 .build()
                 )
+                .putData("type", "GENERAL")
                 .build();
         try {
             firebaseMessaging.send(message);
@@ -194,11 +195,11 @@ public class FcmService {
         return fcmMessage.getId();
     }
 
-    public void dispatchKeywordNotice(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body) {
+    public void dispatchKeywordNotice(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType type, Long targetId) {
         if (fcmMessageId == null || tokenAndMemberId.isEmpty()) {
             return;
         }
-        DeliveryResult deliveryResult = dispatchToMembersInternal(fcmMessageId, tokenAndMemberId, title, body);
+        DeliveryResult deliveryResult = dispatchToMembersInternal(fcmMessageId, tokenAndMemberId, title, body, type, targetId);
         fcmTransactionService.updateFinalStatus(fcmMessageId, deliveryResult.successCount(), deliveryResult.failureCount());
     }
 
@@ -246,7 +247,9 @@ public class FcmService {
                     dispatch.fcmMessageId(),
                     dispatch.tokenAndMemberId(),
                     dispatch.title(),
-                    dispatch.content()
+                    dispatch.content(),
+                    FcmMessageType.GENERAL,
+                    null
             );
 
             // 4. 최종 상태 업데이트
@@ -277,7 +280,7 @@ public class FcmService {
         });
     }
 
-    private DeliveryResult dispatchToMembersInternal(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body) {
+    private DeliveryResult dispatchToMembersInternal(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType type, Long targetId) {
         List<String> tokens = new ArrayList<>(tokenAndMemberId.keySet());
         int batchSize = 500;
         int successCount = 0;
@@ -285,7 +288,7 @@ public class FcmService {
 
         for (int i = 0; i < tokens.size(); i += batchSize) {
             List<String> batchTokens = tokens.subList(i, Math.min(i + batchSize, tokens.size()));
-            MulticastMessage message = createMulticastMessage(batchTokens, title, body);
+            MulticastMessage message = createMulticastMessage(batchTokens, title, body, type, targetId);
 
             int batchSuccess = 0;
             int batchFailure = 0;
@@ -342,7 +345,7 @@ public class FcmService {
                         LinkedHashMap::new
                 ));
 
-        DeliveryResult deliveryResult = dispatchToMembersInternal(null, tokenAndMemberId, title, body);
+        DeliveryResult deliveryResult = dispatchToMembersInternal(null, tokenAndMemberId, title, body, null, null);
         log.info("Untracked notification sent: targets={}, success={}, failure={}",
                 tokenAndMemberId.size(), deliveryResult.successCount(), deliveryResult.failureCount());
     }
@@ -351,7 +354,7 @@ public class FcmService {
      * DB에 이력을 남기면서(알림함 노출) 푸시 알림을 보냅니다.
      */
     @Transactional
-    public TrackedNotificationDispatch prepareTrackedNotification(List<Long> memberIds, String title, String body, FcmMessageType type) {
+    public TrackedNotificationDispatch prepareTrackedNotification(List<Long> memberIds, String title, String body, FcmMessageType type, Long targetId) {
         if (memberIds == null || memberIds.isEmpty()) {
             return null;
         }
@@ -368,7 +371,7 @@ public class FcmService {
         FcmMessage fcmMessage = saveTrackedMessage(title, body, false, tokenAndMemberId.size());
         batchInsertMemberFcmMessages(fcmMessage.getId(), memberIds, type);
 
-        return new TrackedNotificationDispatch(fcmMessage.getId(), tokenAndMemberId, title, body);
+        return new TrackedNotificationDispatch(fcmMessage.getId(), tokenAndMemberId, title, body, type, targetId);
     }
 
     public void dispatchTrackedNotification(TrackedNotificationDispatch dispatch) {
@@ -376,7 +379,7 @@ public class FcmService {
             return;
         }
         if (!dispatch.tokenAndMemberId().isEmpty()) {
-            DeliveryResult deliveryResult = dispatchToMembersInternal(dispatch.fcmMessageId(), dispatch.tokenAndMemberId(), dispatch.title(), dispatch.body());
+            DeliveryResult deliveryResult = dispatchToMembersInternal(dispatch.fcmMessageId(), dispatch.tokenAndMemberId(), dispatch.title(), dispatch.body(), dispatch.type(), dispatch.targetId());
             fcmTransactionService.updateFinalStatus(dispatch.fcmMessageId(), deliveryResult.successCount(), deliveryResult.failureCount());
         } else {
             fcmTransactionService.updateFinalStatus(dispatch.fcmMessageId(), 0, 0);
@@ -419,14 +422,26 @@ public class FcmService {
         return ListResponseDto.of(messages.getTotalPages(), messages.getTotalElements(), notificationResponses);
     }
 
-    private MulticastMessage createMulticastMessage(List<String> tokens, String title, String body) {
-        return MulticastMessage.builder()
+    private MulticastMessage createMulticastMessage(List<String> tokens, String title, String body, FcmMessageType type, Long targetId) {
+        MulticastMessage.Builder builder = MulticastMessage.builder()
                 .addAllTokens(tokens)
                 .setNotification(Notification.builder()
                         .setTitle(title)
                         .setBody(body)
-                        .build())
-                .build();
+                        .build());
+
+        if (type != null) {
+            builder.putData("type", type.name());
+        }
+        if (targetId != null) {
+            builder.putData("targetId", String.valueOf(targetId));
+            
+            // 공지사항인 경우 noticeId로도 탑재해 주어 클라이언트 편의 제공
+            if (type == FcmMessageType.SCHOOL_NOTICE || type == FcmMessageType.DEPARTMENT) {
+                builder.putData("noticeId", String.valueOf(targetId));
+            }
+        }
+        return builder.build();
     }
 
     /**
@@ -624,7 +639,9 @@ public class FcmService {
             Long fcmMessageId,
             Map<String, Long> tokenAndMemberId,
             String title,
-            String body
+            String body,
+            FcmMessageType type,
+            Long targetId
     ) {
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -98,7 +98,7 @@ public class FcmService {
     @Async("messageExecutor")
     public void sendToAdmin(String title, String body) {
         List<String> target = fcmTokenRepository.findAllAdminTokens();
-        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, target.size());
+        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, target.size(), null);
 
         if (target.isEmpty()) {
             return;
@@ -124,7 +124,7 @@ public class FcmService {
     @Async("messageExecutor")
     public void sendToAll(String title, String body) {
         List<String> target = fcmTokenRepository.findAllStringTokens();
-        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, target.size());
+        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, target.size(), null);
 
         if (target.isEmpty()) {
             return;
@@ -178,12 +178,12 @@ public class FcmService {
     }
 
     @Transactional
-    public Long prepareKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType fcmMessageType) {
+    public Long prepareKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType fcmMessageType, Long targetId) {
         if (tokenAndMemberId.isEmpty()) {
             return null;
         }
 
-        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, tokenAndMemberId.size());
+        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, tokenAndMemberId.size(), targetId);
 
         List<Long> targetMemberIds = tokenAndMemberId.values().stream()
                 .filter(id -> id != null && !id.equals(UNLINKED_MEMBER_ID))
@@ -210,7 +210,8 @@ public class FcmService {
                 request.title(),
                 request.content(),
                 true,
-                notificationTargets.tokenAndMemberId().size()
+                notificationTargets.tokenAndMemberId().size(),
+                null
         );
 
         return new AdminNotificationDispatch(
@@ -368,7 +369,7 @@ public class FcmService {
                         LinkedHashMap::new
                 ));
 
-        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, tokenAndMemberId.size());
+        FcmMessage fcmMessage = saveTrackedMessage(title, body, false, tokenAndMemberId.size(), targetId);
         batchInsertMemberFcmMessages(fcmMessage.getId(), memberIds, type);
 
         return new TrackedNotificationDispatch(fcmMessage.getId(), tokenAndMemberId, title, body, type, targetId);
@@ -511,11 +512,12 @@ public class FcmService {
     }
 
 
-    private FcmMessage saveTrackedMessage(String title, String body, boolean adminMessage, int targetCount) {
+    private FcmMessage saveTrackedMessage(String title, String body, boolean adminMessage, int targetCount, Long targetId) {
         FcmMessage fcmMessage = FcmMessage.builder()
                 .title(title)
                 .body(body)
                 .isAdminMessage(adminMessage)
+                .targetId(targetId)
                 .build();
         fcmMessage.markPending(targetCount);
         return fcmMessageRepository.saveAndFlush(fcmMessage);

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -6,6 +6,10 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.MulticastMessage;
 import com.google.firebase.messaging.Notification;
 import com.google.firebase.messaging.SendResponse;
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.AdminNotificationDispatch;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.req.AdminNotificationRequest;
 import kr.inuappcenterportal.inuportal.domain.firebase.dto.req.TokenRequestDto;
@@ -424,6 +428,73 @@ public class FcmService {
                         .build())
                 .build();
     }
+
+    /**
+     * 채팅 알림을 위한 특화된 푸시 발송 메서드 (OS별 그룹화 및 무음 처리 지원)
+     */
+    @Transactional(readOnly = true)
+    public void sendChatNotification(List<Long> memberIds, String title, String body, Long chatRoomId, boolean isMuted) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return;
+        }
+        List<FcmToken> tokens = fcmTokenRepository.findFcmTokensByMemberIds(memberIds);
+        if (tokens.isEmpty()) {
+            return;
+        }
+
+        List<String> tokenStrings = tokens.stream().map(FcmToken::getToken).toList();
+        int batchSize = 500;
+        for (int i = 0; i < tokenStrings.size(); i += batchSize) {
+            List<String> batchTokens = tokenStrings.subList(i, Math.min(i + batchSize, tokenStrings.size()));
+            MulticastMessage message = createChatMessage(batchTokens, title, body, chatRoomId, isMuted);
+            try {
+                BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
+                log.info("Chat push sent: room={}, isMuted={}, targets={}, success={}, failure={}",
+                        chatRoomId, isMuted, batchTokens.size(), response.getSuccessCount(), response.getFailureCount());
+            } catch (Exception e) {
+                log.error("Chat push failed: room={}, isMuted={}, targets={}, error={}",
+                        chatRoomId, isMuted, batchTokens.size(), e.getMessage(), e);
+            }
+        }
+    }
+
+    private MulticastMessage createChatMessage(List<String> tokens, String title, String body, Long chatRoomId, boolean isMuted) {
+        String roomIdStr = String.valueOf(chatRoomId);
+        
+        AndroidNotification.Builder androidNotiBuilder = AndroidNotification.builder()
+                .setTag("room_" + roomIdStr);
+                
+        Aps.Builder apsBuilder = Aps.builder()
+                .setThreadId("room_" + roomIdStr);
+                
+        if (isMuted) {
+            // Android: 무음용 채널 (앱에서 조용히 노출하도록 알림 중요도 낮춤)
+            androidNotiBuilder.setChannelId("chat_channel_muted");
+        } else {
+            // Android: 소리/진동용 기본 채널
+            androidNotiBuilder.setChannelId("chat_channel_default");
+            // iOS: 소리가 나도록 default 설정
+            apsBuilder.setSound("default");
+        }
+
+        return MulticastMessage.builder()
+                .addAllTokens(tokens)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                // 웹뷰에서 라우팅할 때 참조할 공통 데이터 페이로드
+                .putData("type", "CHAT")
+                .putData("chatRoomId", roomIdStr)
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setNotification(androidNotiBuilder.build())
+                        .build())
+                .setApnsConfig(ApnsConfig.builder()
+                        .setAps(apsBuilder.build())
+                        .build())
+                .build();
+    }
+
 
     private FcmMessage saveTrackedMessage(String title, String body, boolean adminMessage, int targetCount) {
         FcmMessage fcmMessage = FcmMessage.builder()

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/keyword/service/KeywordService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/keyword/service/KeywordService.java
@@ -102,7 +102,7 @@ public class KeywordService {
         }
 
         titleToTokens.forEach((title, tokenMap) -> 
-            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, notice.getTitle(), FcmMessageType.SCHOOL_NOTICE)
+            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, notice.getTitle(), FcmMessageType.SCHOOL_NOTICE, notice.getId())
         );
     }
 
@@ -151,7 +151,7 @@ public class KeywordService {
 
         final String finalBody = body;
         titleToTokens.forEach((title, tokenMap) -> 
-            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, finalBody, FcmMessageType.DEPARTMENT)
+            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, finalBody, FcmMessageType.DEPARTMENT, departmentNotice.getId())
         );
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
@@ -58,7 +58,7 @@ public class FriendService {
                 .build();
         friendRepository.save(friend);
 
-        fcmAsyncService.sendAsyncTrackedNotification(List.of(receiver.getId()), "친구 요청", requester.getNickname() + "님이 친구 요청을 보냈습니다.", FcmMessageType.FRIEND);
+        fcmAsyncService.sendAsyncTrackedNotification(List.of(receiver.getId()), "친구 요청", requester.getNickname() + "님이 친구 요청을 보냈습니다.", FcmMessageType.FRIEND, friend.getId());
     }
 
     @Transactional(readOnly = true)
@@ -126,7 +126,7 @@ public class FriendService {
 
         friend.accept();
 
-        fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 수락", friend.getReceiver().getNickname() + "님이 친구 요청을 수락했습니다.", FcmMessageType.FRIEND);
+        fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 수락", friend.getReceiver().getNickname() + "님이 친구 요청을 수락했습니다.", FcmMessageType.FRIEND, friend.getId());
     }
 
     @Transactional
@@ -139,7 +139,7 @@ public class FriendService {
         }
 
         if (friend.getStatus() == FriendStatus.PENDING && friend.getReceiver().getId().equals(memberId)) {
-            fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 요청 결과", "친구 요청이 거절되었습니다.", FcmMessageType.FRIEND);
+            fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 요청 결과", "친구 요청이 거절되었습니다.", FcmMessageType.FRIEND, friend.getId());
         }
 
         friendRepository.delete(friend);

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
@@ -20,6 +20,7 @@ import kr.inuappcenterportal.inuportal.global.dto.ListResponseDto;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.jsoup.Connection;
@@ -49,18 +50,7 @@ import java.security.MessageDigest;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.HexFormat;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -131,6 +121,11 @@ public class NoticeService {
     }
 
     @Scheduled(cron = "0 0/15 * * * *")
+    @SchedulerLock(
+            name = "notice-school-crawl",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M"
+    )
     @CacheEvict(value = "noticeCache", cacheManager = "cacheManager")
     @Transactional
     public void getNewNotice() {
@@ -138,6 +133,11 @@ public class NoticeService {
     }
 
     @Scheduled(cron = "0 0/10 * * * *")
+    @SchedulerLock(
+            name = "notice-department-crawl",
+            lockAtMostFor = "PT5M",
+            lockAtLeastFor = "PT30S"
+    )
     @CacheEvict(value = "noticeCache", cacheManager = "cacheManager")
     @Transactional
     public void getNewDepartmentNotice() {
@@ -152,6 +152,11 @@ public class NoticeService {
     }
 
     @Scheduled(cron = "0 5/10 * * * *")
+    @SchedulerLock(
+            name = "notice-department-content-backfill",
+            lockAtMostFor = "PT5M",
+            lockAtLeastFor = "PT30S"
+    )
     @Transactional
     public void backfillDepartmentNoticeContents() {
         Department[] departments = Department.values();
@@ -165,6 +170,11 @@ public class NoticeService {
     }
 
     @Scheduled(cron = "0 7/10 * * * *")
+    @SchedulerLock(
+            name = "notice-department-content-enrich",
+            lockAtMostFor = "PT8M",
+            lockAtLeastFor = "PT30S"
+    )
     @Transactional
     public void enrichDepartmentNoticeContents() {
         Department[] departments = Department.values();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/post/service/PostService.java
@@ -21,6 +21,7 @@ import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
 import kr.inuappcenterportal.inuportal.domain.image.service.ImageService;
 import kr.inuappcenterportal.inuportal.global.service.RedisService;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
@@ -86,6 +87,11 @@ public class PostService {
     }
 
     @Scheduled(cron = "0 0 0 * * *")
+    @SchedulerLock(
+            name = "post-shuffle",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M"
+    )
     @Transactional
     public void shufflePosts() {
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/schedule/service/ScheduleService.java
@@ -8,6 +8,7 @@ import kr.inuappcenterportal.inuportal.domain.schedule.model.Schedule;
 import kr.inuappcenterportal.inuportal.domain.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -45,6 +46,11 @@ public class ScheduleService {
     private static long id = 0L;
 
     @Scheduled(cron = "0 0 0 1 * *")
+    @SchedulerLock(
+            name = "schedule-cleanup",
+            lockAtMostFor = "PT30M",
+            lockAtLeastFor = "PT1M"
+    )
     @Transactional
     public void renewalSchedule() throws InterruptedException {
         crawlingSchedule();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/weather/service/WeatherService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/weather/service/WeatherService.java
@@ -12,6 +12,7 @@ import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
 import kr.inuappcenterportal.inuportal.global.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -46,6 +47,11 @@ public class WeatherService {
     private final String y = "123";
 
     @Scheduled(cron = "0 35 * * * *")
+    @SchedulerLock(
+            name = "weather-hourly",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M"
+    )
     public void getWeatherAPI(){
         try {
             getWeatherSky();
@@ -67,6 +73,11 @@ public class WeatherService {
     }
 
     @Scheduled(cron = "0 5 0 * * *")
+    @SchedulerLock(
+            name = "weather-daily",
+            lockAtMostFor = "PT10M",
+            lockAtLeastFor = "PT1M"
+    )
     public void getDay() {
         getDayData();
     }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/ShedLockConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/ShedLockConfig.java
@@ -1,17 +1,44 @@
 package kr.inuappcenterportal.inuportal.global.config;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
 import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import java.util.Optional;
 
 @Configuration
 @EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
 public class ShedLockConfig {
 
     @Bean
-    public RedisLockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+    public RedisLockProvider redisLockProvider(RedisConnectionFactory connectionFactory) {
         return new RedisLockProvider(connectionFactory, "inu-portal");
+    }
+
+    @Bean
+    @Primary
+    public LockProvider meteredLockProvider(RedisLockProvider delegate, MeterRegistry registry) {
+        return new LockProvider() {
+            @Override
+            public Optional<SimpleLock> lock(LockConfiguration config) {
+                Optional<SimpleLock> result = delegate.lock(config);
+                if (result.isEmpty()) {
+                    Counter.builder("intip_scheduler_executions_total")
+                            .tag("name", config.getName())
+                            .tag("result", "skipped")
+                            .register(registry)
+                            .increment();
+                }
+                return result;
+            }
+        };
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/ShedLockConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/ShedLockConfig.java
@@ -1,0 +1,17 @@
+package kr.inuappcenterportal.inuportal.global.config;
+
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+public class ShedLockConfig {
+
+    @Bean
+    public RedisLockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        return new RedisLockProvider(connectionFactory, "inu-portal");
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/logging/service/LoggingService.java
@@ -11,6 +11,7 @@ import kr.inuappcenterportal.inuportal.global.logging.dto.res.LoggingMemberRespo
 import kr.inuappcenterportal.inuportal.global.logging.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -70,6 +71,11 @@ public class LoggingService {
 
     // 매일 00시에 실행
     @Scheduled(cron = "0 0 0 * * *")
+    @SchedulerLock(
+            name = "logging-cleanup",
+            lockAtMostFor = "PT30M",
+            lockAtLeastFor = "PT5M"
+    )
     @Transactional
     public void summarizeDailyLogs() {
         LocalDate oneDayAgo = LocalDate.now().minusDays(1);

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/metric/ScheduledMethodMetricsAspect.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/metric/ScheduledMethodMetricsAspect.java
@@ -1,0 +1,62 @@
+package kr.inuappcenterportal.inuportal.global.metric;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Aspect
+@Component
+public class ScheduledMethodMetricsAspect {
+
+    private final MeterRegistry registry;
+
+    public ScheduledMethodMetricsAspect(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Around("@annotation(org.springframework.scheduling.annotation.Scheduled)")
+    public Object recordScheduledExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        String name = resolveName(joinPoint);
+        long startNanos = System.nanoTime();
+
+        try {
+            Object result = joinPoint.proceed();
+            Counter.builder("intip_scheduler_executions_total")
+                    .tag("name", name)
+                    .tag("result", "success")
+                    .register(registry)
+                    .increment();
+            return result;
+        } catch (Throwable e) {
+            Counter.builder("intip_scheduler_executions_total")
+                    .tag("name", name)
+                    .tag("result", "failure")
+                    .register(registry)
+                    .increment();
+            throw e;
+        } finally {
+            Timer.builder("intip_scheduler_duration_seconds")
+                    .tag("name", name)
+                    .publishPercentiles(0.5, 0.95, 0.99)
+                    .register(registry)
+                    .record(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+
+    private String resolveName(ProceedingJoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        SchedulerLock lock = signature.getMethod().getAnnotation(SchedulerLock.class);
+        if (lock != null && !lock.name().isBlank()) {
+            return lock.name();
+        }
+        return signature.getDeclaringType().getSimpleName() + "." + signature.getName();
+    }
+}


### PR DESCRIPTION
## 📎 관련 이슈

- 관련 이슈 없음 (운영 안정성 개선 작업)

## 📄 설명

다중 인스턴스 배포·무중단 배포 환경에서 스케줄러가 중복 실행되어 데이터 무결성 / 외부 API 부담 / FCM 중복 발송이 발생할 수 있는 위험을 차단하고, 차단 효과를 정량 데이터로 가시화하기 위한 작업입니다.

### 1. ShedLock 기반 분산 락 도입

- Redis(`RedisLockProvider`)를 백엔드로 사용해 `@SchedulerLock`이 붙은 스케줄러는 클러스터 전체에서 단 하나의 인스턴스만 실행되도록 강제합니다.
- `@Scheduled` 17개 중 16개에 적용했습니다. (`ChatBatchService`는 fixedDelay 2s 주기로 분산 락 오버헤드가 커서 DB 단의 멱등성으로 대체)
- 각 스케줄러의 평균/최악 실행 시간을 기반으로 `lockAtMostFor` / `lockAtLeastFor`를 개별 산정했습니다.

### 2. AOP 기반 스케줄러 실행 메트릭

- `@Scheduled` 어노테이션이 붙은 모든 메서드를 `@Around`로 가로채 success / failure / duration을 Micrometer로 자동 publish합니다.
- 메트릭의 `name` 태그는 `@SchedulerLock.name()`을 1순위로 사용하여 락 정책과 메트릭 라벨이 자연스럽게 매핑되도록 했습니다.


### 3. LockProvider 메트릭 래퍼

- ShedLock의 락 획득 실패(=중복 실행 차단)는 메서드 자체가 호출되지 않아 일반 AOP로 감지 불가합니다.
- `LockProvider`를 데코레이터 패턴으로 감싸고 `@Primary`로 노출하여 `Optional.empty()` 시점에 `result="skipped"` 카운터를 증가시킵니다.
- 결과적으로 하나의 메트릭(`intip_scheduler_executions_total`)에 success / failure / skipped 세 가지 result가 통합 publish됩니다.