### PR TITLE
234 fix 학과 공지 크롤링 이슈 개선

### DIFF
--- a/.idea/IntelliLang.xml
+++ b/.idea/IntelliLang.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="LanguageInjectionConfiguration">
+    <injection language="SQL" injector-id="java">
+      <display-name>AsyncQueryRunner (org.apache.commons.dbutils)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("batch").withParameterCount(2).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("insertBatch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("batch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("insertBatch").withParameterCount(4).definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.AsyncQueryRunner"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Jodd (jodd.db)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query").withParameterCount(1).definedInClass("jodd.db.DbQuery"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("DbQuery").withParameterCount(2).definedInClass("jodd.db.DbQuery"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query").withParameterCount(2).definedInClass("jodd.db.DbQuery"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(2, psiMethod().withName("DbQuery").withParameterCount(3).definedInClass("jodd.db.DbQuery"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>MyBatis @Select/@Delete/@Insert/@Update</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Delete")]]></place>
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Insert")]]></place>
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Select")]]></place>
+      <place><![CDATA[psiMethod().withName("value").withParameters().definedInClass("org.apache.ibatis.annotations.Update")]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>QueryRunner (org.apache.commons.dbutils)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("batch").withParameterCount(2).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("insertBatch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "insert", "execute").withParameters("java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update").withParameters("java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("update", "execute").withParameters("java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("batch").withParameterCount(3).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("insertBatch").withParameterCount(4).definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("query", "insert", "execute").withParameters("java.sql.Connection", "java.lang.String", "org.apache.commons.dbutils.ResultSetHandler").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(1, psiMethod().withName("update", "execute").withParameters("java.sql.Connection", "java.lang.String", "java.lang.Object...").definedInClass("org.apache.commons.dbutils.QueryRunner"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>R2DBC (io.r2dbc)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("add").definedInClass("io.r2dbc.spi.Batch"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("createStatement").definedInClass("io.r2dbc.spi.Connection"))]]></place>
+    </injection>
+    <injection language="PostgreSQL" injector-id="java">
+      <display-name>Reactiverse Postgres Client (io.reactiverse)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgTransaction"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgPool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.reactiverse.reactivex.pgclient.PgTransaction"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.axle.pgclient.PgClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.reactiverse.pgclient.PgPool"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>SmallRye Axle SqlClient (io.vertx.axle.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.axle.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.axle.sqlclient.SqlClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>SmallRye Mutiny SqlClient (io.vertx.mutiny.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mutiny.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mutiny.sqlclient.SqlClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>SmallRye Mutiny SqlConnection (io.vertx.mutiny.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.db2client.DB2Connection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.mssqlclient.MSSQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.mysqlclient.MySQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("prepare", "prepareAndAwait").definedInClass("io.vertx.mutiny.pgclient.PgConnection"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SQL Extensions (io.vertx.ext.sql)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams").definedInClass("io.vertx.ext.sql.SQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams").definedInClass("io.vertx.ext.sql.SQLOperations"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams", "execute", "batchWithParams", "batchCallableWithParams").definedInClass("io.vertx.ext.sql.SQLConnection"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SQL Reactive Extensions (io.vertx.reactivex.ext.sql)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams").definedInClass("io.vertx.reactivex.ext.sql.SQLOperations"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams", "execute", "batchWithParams", "batchCallableWithParams", "rxQuerySingle", "rxQuerySingleWithParams", "rxQuery", "rxQueryWithParams", "rxQueryStream", "rxQueryStreamWithParams", "rxUpdate", "rxUpdateWithParams", "rxCall", "rxCallWithParams", "rxExecute", "rxBatchWithParams", "rxBatchCallableWithParams").definedInClass("io.vertx.reactivex.ext.sql.SQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "queryWithParams", "queryStream", "queryStreamWithParams", "querySingle", "querySingleWithParams", "update", "updateWithParams", "call", "callWithParams", "execute", "batchWithParams", "batchCallableWithParams", "rxQuerySingle", "rxQuerySingleWithParams", "rxQuery", "rxQueryWithParams", "rxQueryStream", "rxQueryStreamWithParams", "rxUpdate", "rxUpdateWithParams", "rxCall", "rxCallWithParams", "rxExecute", "rxBatchWithParams", "rxBatchCallableWithParams").definedInClass("io.vertx.reactivex.ext.sql.SQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("querySingle", "rxQuerySingle", "querySingleWithParams", "rxQuerySingleWithParams").definedInClass("io.vertx.reactivex.ext.asyncsql.AsyncSQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("querySingle", "rxQuerySingle", "querySingleWithParams", "rxQuerySingleWithParams").definedInClass("io.vertx.reactivex.ext.asyncsql.MySQLClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("querySingle", "rxQuerySingle", "querySingleWithParams", "rxQuerySingleWithParams").definedInClass("io.vertx.reactivex.ext.asyncsql.PostgreSQLClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SqlClient (io.vertx.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mssqlclient.MSSQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.mysqlclient.MySQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.SqlClient"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.SqlConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch").definedInClass("io.vertx.sqlclient.Transaction"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>Vert.x SqlClient RxJava2 (io.vertx.reactivex.sqlclient)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.mysqlclient.MySQLConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.pgclient.PgConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.SqlConnection"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPrepare", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.Transaction"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.mysqlclient.MySQLPool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.pgclient.PgPool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.Pool"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "prepare", "preparedQuery", "preparedBatch", "rxQuery", "rxPreparedQuery", "rxPreparedBatch").definedInClass("io.vertx.reactivex.sqlclient.SqlClient"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>jOOQ (org.jooq.DSLContext)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("batch").withParameters("java.lang.String", "java.lang.Object[]...").definedInClass("org.jooq.DSLContext"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "fetch", "fetchLazy", "fetchAsync", "fetchStream", "fetchMany", "fetchOne", "fetchSingle", "fetchOptional", "fetchValue", "fetchOptionalValue", "fetchValues", "execute", "resultQuery").withParameters("java.lang.String", "java.lang.Object...").definedInClass("org.jooq.DSLContext"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("query", "fetch", "fetchLazy", "fetchAsync", "fetchStream", "fetchMany", "fetchOne", "fetchSingle", "fetchOptional", "fetchValue", "fetchOptionalValue", "fetchValues", "execute", "resultQuery", "batch").withParameters("java.lang.String").definedInClass("org.jooq.DSLContext"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(psiMethod().withName("batch").withParameters("java.lang.String...").definedInClass("org.jooq.DSLContext"))]]></place>
+    </injection>
+    <injection language="SQL" injector-id="java">
+      <display-name>rxjava2-jdbc (org.davidmoten.rx.jdbc)</display-name>
+      <single-file value="true" />
+      <place><![CDATA[psiMethod().withName("value").definedInClass("org.davidmoten.rx.jdbc.annotations.Query")]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("call", "select", "update").definedInClass("org.davidmoten.rx.jdbc.Database"))]]></place>
+      <place><![CDATA[psiParameter().ofMethod(0, psiMethod().withName("call", "select", "update").definedInClass("org.davidmoten.rx.jdbc.TransactedBuilder"))]]></place>
+    </injection>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,7 +3,6 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/inu-portal.main.iml" filepath="$PROJECT_DIR$/.idea/modules/inu-portal.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/inu-portal.test.iml" filepath="$PROJECT_DIR$/.idea/modules/inu-portal.test.iml" />
     </modules>
   </component>
 </project>

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/controller/NoticeController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/controller/NoticeController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import kr.inuappcenterportal.inuportal.domain.notice.dto.DepartmentNoticeListResponse;
+import kr.inuappcenterportal.inuportal.domain.notice.dto.DepartmentNoticePageResponse;
 import kr.inuappcenterportal.inuportal.domain.notice.dto.NoticeListResponseDto;
 import kr.inuappcenterportal.inuportal.domain.notice.enums.Department;
 import kr.inuappcenterportal.inuportal.domain.notice.service.NoticeService;
@@ -102,7 +103,7 @@ public class NoticeController {
             @ApiResponse(
                     responseCode = "200",
                     description = "학과별 공지사항 가져오기 성공",
-                    content = @Content(schema = @Schema(implementation = DepartmentNoticeListResponse.class))
+                    content = @Content(schema = @Schema(implementation = DepartmentNoticePageResponse.class))
             ),
             @ApiResponse(
                     responseCode = "400",
@@ -111,7 +112,7 @@ public class NoticeController {
             )
     })
     @GetMapping("/department")
-    public ResponseEntity<ResponseDto<ListResponseDto<DepartmentNoticeListResponse>>> getDepartmentNotices(
+    public ResponseEntity<ResponseDto<DepartmentNoticePageResponse>> getDepartmentNotices(
             @RequestParam Department department,
             @RequestParam(required = false, defaultValue = "date") String sort,
             @RequestParam(required = false, defaultValue = "1") @Min(1) int page

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/dto/DepartmentNoticePageResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/dto/DepartmentNoticePageResponse.java
@@ -1,0 +1,27 @@
+package kr.inuappcenterportal.inuportal.domain.notice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "학과 공지사항 페이지 응답")
+public record DepartmentNoticePageResponse(
+
+        @Schema(description = "총 페이지 수", example = "10")
+        long pages,
+
+        @Schema(description = "총 게시글 수", example = "80")
+        long total,
+
+        @Schema(description = "게시글 리스트")
+        List<DepartmentNoticeListResponse> contents,
+
+        @Schema(description = "서비스 가능 여부", example = "true")
+        boolean isServiceAvailable,
+
+        @Schema(description = "게시글 내용 조회 가능 여부", example = "true")
+        boolean isContentAvailable
+) {
+    public static DepartmentNoticePageResponse of(long pages, long total, List<DepartmentNoticeListResponse> contents, boolean isServiceAvailable, boolean isContentAvailable) {
+        return new DepartmentNoticePageResponse(pages, total, contents, isServiceAvailable, isContentAvailable);
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/enums/Department.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/enums/Department.java
@@ -1,106 +1,122 @@
 package kr.inuappcenterportal.inuportal.domain.notice.enums;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public enum Department {
 
     // 총 64개 학과
 
     // 인문대학
-    KOREAN("국어국문학과", "https://korean.inu.ac.kr/korean/1780/subview.do"),
-    ENGLISH("영어영문학과", "https://english.inu.ac.kr/ui/7888/subview.do"),
-    GERMAN("독어독문학과", "https://german.inu.ac.kr/german/1841/subview.do"),
-    FRENCH("불어불문학과", "https://inufrance.inu.ac.kr/inufrance/1915/subview.do"),
-    JAPANESE("일본지역문화학과", "https://unjapan.inu.ac.kr/unjapan/2025/subview.do"),
-    CHINESE("중어중국학과", "https://inuchina.inu.ac.kr/inuchina/2096/subview.do"),
+    KOREAN("국어국문학과", "https://korean.inu.ac.kr/korean/1780/subview.do", "https://www.inu.ac.kr/bbs/isis/286/rssList.do?row=10"),
+    ENGLISH("영어영문학과", "https://english.inu.ac.kr/ui/7888/subview.do", "https://www.inu.ac.kr/bbs/isis/642/rssList.do?row=10"),
+    GERMAN("독어독문학과", "https://german.inu.ac.kr/german/1841/subview.do", "https://www.inu.ac.kr/bbs/isis/289/rssList.do?row=10"),
+    FRENCH("불어불문학과", "https://inufrance.inu.ac.kr/inufrance/1915/subview.do", "https://www.inu.ac.kr/bbs/isis/292/rssList.do?row=10"),
+    JAPANESE("일본지역문화학과", "https://unjapan.inu.ac.kr/unjapan/2025/subview.do", "https://www.inu.ac.kr/bbs/isis/298/rssList.do?row=10"),
+    CHINESE("중어중국학과", "https://inuchina.inu.ac.kr/inuchina/2096/subview.do", "https://www.inu.ac.kr/bbs/isis/301/rssList.do?row=10"),
 
     // 자연과학대학
-    MATHEMATICS("수학과", "https://math.inu.ac.kr/isu/2219/subview.do"),
-    PHYSICS("물리학과", "https://physics.inu.ac.kr/physics/2155/subview.do"),
-    CHEMISTRY("화학과", "https://chem.inu.ac.kr/chem/2389/subview.do"),
-    FASHION("패션산업학과", "https://uifashion.inu.ac.kr/uifashion/2271/subview.do"),
-    MARINE("해양학과", "https://marine.inu.ac.kr/marine/2323/subview.do"),
+    MATHEMATICS("수학과", "https://math.inu.ac.kr/isu/2219/subview.do", "https://www.inu.ac.kr/bbs/isis/307/rssList.do?row=10"),
+    PHYSICS("물리학과", "https://physics.inu.ac.kr/physics/2155/subview.do", "https://www.inu.ac.kr/bbs/isis/304/rssList.do?row=10"),
+    CHEMISTRY("화학과", "https://chem.inu.ac.kr/chem/2389/subview.do", "https://www.inu.ac.kr/bbs/isis/316/rssList.do?row=10"),
+    FASHION("패션산업학과", "https://uifashion.inu.ac.kr/uifashion/2271/subview.do", "https://www.inu.ac.kr/bbs/isis/1735/rssList.do?row=10"),
+    MARINE("해양학과", "https://marine.inu.ac.kr/marine/2323/subview.do", "https://www.inu.ac.kr/bbs/isis/313/rssList.do?row=10"),
 
     // 사회과학대학
-    SOCIAL_WELFARE("사회복지학과", "https://dsw.inu.ac.kr/dsw/2493/subview.do"),
-    MEDIA_COMMUNICATION("미디어커뮤니케이션학과", "https://newdays.inu.ac.kr/shinbang/2541/subview.do"),
-    LIBRARY_INFO("문헌정보학과", "https://cls.inu.ac.kr/cls/2448/subview.do"),
-    CREATIVE_HRD("창의인재개발학과", "https://hrd.inu.ac.kr/hrd/2580/subview.do"),
+    SOCIAL_WELFARE("사회복지학과", "https://dsw.inu.ac.kr/dsw/2493/subview.do", "https://www.inu.ac.kr/bbs/isis/322/rssList.do?row=10"),
+    MEDIA_COMMUNICATION("미디어커뮤니케이션학과", "https://newdays.inu.ac.kr/shinbang/2541/subview.do", "https://www.inu.ac.kr/bbs/isis/1697/rssList.do?row=10"),
+    LIBRARY_INFO("문헌정보학과", "https://cls.inu.ac.kr/cls/2448/subview.do", "https://www.inu.ac.kr/bbs/isis/319/rssList.do?row=10"),
+    CREATIVE_HRD("창의인재개발학과", "https://hrd.inu.ac.kr/hrd/2580/subview.do", "https://www.inu.ac.kr/bbs/isis/328/rssList.do?row=10"),
 
     // 글로벌정경대학
-    PUBLIC_ADMINISTRATION("행정학과", "https://uipa.inu.ac.kr/uipa/7800/subview.do"),
-    POLITICS_DIPLOMACY("정치외교학과", "https://politics.inu.ac.kr/politics/2742/subview.do"),
-    ECONOMICS("경제학과", "https://econ.inu.ac.kr/econ/2643/subview.do"),
-    TRADE("무역학부", "https://trade.inu.ac.kr/trade/2693/subview.do"),
-    CONSUMER_SCIENCE("소비자학과", "https://ccs.inu.ac.kr/ccs/2789/subview.do"),
+    PUBLIC_ADMINISTRATION("행정학과", "https://uipa.inu.ac.kr/uipa/7800/subview.do", "https://www.inu.ac.kr/bbs/isis/1707/rssList.do?row=10"),
+    POLITICS_DIPLOMACY("정치외교학과", "https://politics.inu.ac.kr/politics/2742/subview.do", "https://www.inu.ac.kr/bbs/isis/337/rssList.do?row=10"),
+    ECONOMICS("경제학과", "https://econ.inu.ac.kr/econ/2643/subview.do", "https://www.inu.ac.kr/bbs/isis/331/rssList.do?row=10"),
+    TRADE("Global Trade & Service 학부", "https://trade.inu.ac.kr/trade/2693/subview.do", "https://www.inu.ac.kr/bbs/isis/334/rssList.do?row=10"),
+    CONSUMER_SCIENCE("소비자학과", "https://ccs.inu.ac.kr/ccs/2789/subview.do", "https://www.inu.ac.kr/bbs/isis/340/rssList.do?row=10", true, false, true),
 
     // 공과대학
-    ENERGY_CHEMICAL("에너지화학공학과", "https://energy.inu.ac.kr/energy/3270/subview.do"),
-    ELECTRICAL_ENGINEERING("전기공학과", "https://elec.inu.ac.kr/elec/3324/subview.do"),
-    ELECTRONICS_ENGINEERING("전자공학과", "https://ee.inu.ac.kr/electron/3376/subview.do"),
-    INDUSTRIAL_MANAGEMENT("산업경영공학과", "https://ime.inu.ac.kr/ime/3101/subview.do"),
-    MATERIAL_SCIENCE("신소재공학과", "https://mse.inu.ac.kr/mse/3148/subview.do"),
-    MECHANICAL_ENGINEERING("기계공학과", "https://me.inu.ac.kr/me/2989/subview.do"),
-    BIO_ROBOTICS_ENGINEERING("바이오로봇시스템공학과", "https://bio-robot.inu.ac.kr/meca/3049/subview.do"),
-    SAFETY_ENGINEERING("안전공학과", "https://safety.inu.ac.kr/safety/3206/subview.do"),
+    ENERGY_CHEMICAL("에너지화학공학과", "https://energy.inu.ac.kr/energy/3270/subview.do", "https://www.inu.ac.kr/bbs/isis/868/rssList.do?row=10"),
+    ELECTRICAL_ENGINEERING("전기공학과", "https://elec.inu.ac.kr/elec/3324/subview.do", "https://www.inu.ac.kr/bbs/isis/364/rssList.do?row=10"),
+    ELECTRONICS_ENGINEERING("전자공학과", "https://ee.inu.ac.kr/electron/3376/subview.do", "https://www.inu.ac.kr/bbs/isis/367/rssList.do?row=10", true, false, true),
+    INDUSTRIAL_MANAGEMENT("산업경영공학과", "https://ime.inu.ac.kr/ime/3101/subview.do", "https://www.inu.ac.kr/bbs/isis/826/rssList.do?row=10", true, true, false),
+    MATERIAL_SCIENCE("신소재공학과", "https://mse.inu.ac.kr/mse/3148/subview.do", "https://www.inu.ac.kr/bbs/isis/355/rssList.do?row=10", true, false, true),
+    MECHANICAL_ENGINEERING("기계공학과", "https://me.inu.ac.kr/me/2989/subview.do", "https://www.inu.ac.kr/bbs/isis/814/rssList.do?row=10"),
+    BIO_ROBOTICS_ENGINEERING("바이오로봇시스템공학과", "https://bio-robot.inu.ac.kr/meca/3049/subview.do", "https://www.inu.ac.kr/bbs/isis/349/rssList.do?row=10"),
+    SAFETY_ENGINEERING("안전공학과", "https://safety.inu.ac.kr/safety/3206/subview.do", "https://www.inu.ac.kr/bbs/isis/358/rssList.do?row=10"),
 
     // 정보기술대학
-    COMPUTER_ENGINEERING("컴퓨터공학부", "https://cse.inu.ac.kr/isis/3519/subview.do"),
-    INFORMATION_COMMUNICATION_ENGINEERING("정보통신공학과", "https://ite.inu.ac.kr/ite/3472/subview.do"),
-    EMBEDDED_SYSTEM("임베디드시스템공학과", "https://ese.inu.ac.kr/ese/3428/subview.do"),
+    COMPUTER_ENGINEERING("컴퓨터공학부", "https://cse.inu.ac.kr/isis/3519/subview.do", "https://www.inu.ac.kr/bbs/isis/376/rssList.do?row=10"),
+    INFORMATION_COMMUNICATION_ENGINEERING("정보통신공학과", "https://ite.inu.ac.kr/ite/3472/subview.do", "https://www.inu.ac.kr/bbs/isis/373/rssList.do?row=10"),
+    EMBEDDED_SYSTEM("임베디드시스템공학과", "https://ese.inu.ac.kr/ese/3428/subview.do", "https://www.inu.ac.kr/bbs/isis/370/rssList.do?row=10"),
 
     // 경영대학
-    BUSINESS_ADMINISTRATION("경영학부", "https://biz.inu.ac.kr/biz/3612/subview.do"),
-    DATA_SCIENCE("데이터과학과", "https://datascience.inu.ac.kr/datascience/3713/subview.do"),
-    TAX_ACCOUNTING("세무회계학과", "https://tax.inu.ac.kr/tax/3665/subview.do"),
-    TECHNO_MANAGEMENT("테크노경영학과", "https://www.inu.ac.kr/contract/11456/subview.do"),
+    BUSINESS_ADMINISTRATION("경영학부", "https://biz.inu.ac.kr/biz/3612/subview.do", "https://www.inu.ac.kr/bbs/isis/379/rssList.do?row=10"),
+    DATA_SCIENCE("데이터과학과", "https://datascience.inu.ac.kr/datascience/3713/subview.do", "https://www.inu.ac.kr/bbs/isis/1825/rssList.do?row=10", false, true, true),
+    TAX_ACCOUNTING("세무회계학과", "https://tax.inu.ac.kr/tax/3665/subview.do", "https://www.inu.ac.kr/bbs/isis/384/rssList.do?row=10"),
+    TECHNO_MANAGEMENT("계약학과", "https://www.inu.ac.kr/contract/11207/subview.do", "https://www.inu.ac.kr/bbs/isis/2790/rssList.do?row=10"),
 
     // 예술체육대학
-    FINE_ARTS("조형예술학부", "https://finearts.inu.ac.kr/finearts/4130/subview.do"),
-    DESIGN("디자인학부", "https://design.inu.ac.kr/design/4016/subview.do"),
-    PERFORMING_ART("공연예술학과", "https://uipa10.inu.ac.kr/uipa10/3957/subview.do"),
-    SPORTS_SCIENCE("스포츠과학부", "https://sports.inu.ac.kr/bbs/board.php?bo_table=sub5_1"),
-    HEALTH_EXERCISE("운동건강학부", "https://uiex.inu.ac.kr/uiex/4068/subview.do"),
+    FINE_ARTS("조형예술학부", "https://finearts.inu.ac.kr/finearts/4130/subview.do", "https://www.inu.ac.kr/bbs/isis/409/rssList.do?row=10"),
+    DESIGN("디자인학부", "https://design.inu.ac.kr/design/4016/subview.do", "https://www.inu.ac.kr/bbs/isis/1842/rssList.do?row=10", false, true, false),
+    PERFORMING_ART("공연예술학과", "https://uipa10.inu.ac.kr/uipa10/3957/subview.do", "https://www.inu.ac.kr/bbs/isis/400/rssList.do?row=10"),
+    SPORTS_SCIENCE("스포츠과학부", "https://sports.inu.ac.kr/bbs/board.php?bo_table=sub5_1", null, false, true, true),
+    HEALTH_EXERCISE("운동건강학부", "https://uiex.inu.ac.kr/uiex/4068/subview.do", "https://www.inu.ac.kr/bbs/isis/406/rssList.do?row=10"),
 
     // 사범대학
-    KOREAN_EDUCATION("국어교육과", "https://edukorean.inu.ac.kr/edukorean/4262/subview.do"),
-    ENGLISH_EDUCATION("영어교육과", "https://eduenglish.inu.ac.kr/eduenglish/4436/subview.do"),
-    JAPANESE_EDUCATION("일어교육과", "https://edujapanese.inu.ac.kr/edujapanese/4609/subview.do"),
-    MATH_EDUCATION("수학교육과", "https://mathedu.inu.ac.kr/edumath/4319/subview.do"),
-    PHYSICAL_EDUCATION("체육교육과", "https://eduphysical.inu.ac.kr/eduphysical/4650/subview.do"),
-    EARLY_CHILDHOOD_EDUCATION("유아교육과", "https://ece.inu.ac.kr/ece/4492/subview.do"),
-    HISTORY_EDUCATION("역사교육과", "https://eduhistory.inu.ac.kr/eduhistory/8001/subview.do"),
-    ETHICS_EDUCATION("윤리교육과", "https://eduethics.inu.ac.kr/eduethics/4546/subview.do"),
+    KOREAN_EDUCATION("국어교육과", "https://edukorean.inu.ac.kr/edukorean/4262/subview.do", "https://www.inu.ac.kr/bbs/isis/1074/rssList.do?row=10"),
+    ENGLISH_EDUCATION("영어교육과", "https://eduenglish.inu.ac.kr/eduenglish/4436/subview.do", "https://www.inu.ac.kr/bbs/isis/1123/rssList.do?row=10"),
+    JAPANESE_EDUCATION("일어교육과", "https://edujapanese.inu.ac.kr/edujapanese/4609/subview.do", "https://www.inu.ac.kr/bbs/isis/1176/rssList.do?row=10"),
+    MATH_EDUCATION("수학교육과", "https://mathedu.inu.ac.kr/edumath/4319/subview.do", "https://www.inu.ac.kr/bbs/isis/1088/rssList.do?row=10"),
+    PHYSICAL_EDUCATION("체육교육과", "https://eduphysical.inu.ac.kr/eduphysical/4650/subview.do", null, false, true, true),
+
+    EARLY_CHILDHOOD_EDUCATION("유아교육과", "https://ece.inu.ac.kr/ece/4492/subview.do", "https://www.inu.ac.kr/bbs/isis/1143/rssList.do?row=10"),
+    HISTORY_EDUCATION("역사교육과", "https://eduhistory.inu.ac.kr/eduhistory/8001/subview.do", "https://www.inu.ac.kr/bbs/isis/1104/rssList.do?row=10"),
+    ETHICS_EDUCATION("윤리교육과", "https://eduethics.inu.ac.kr/eduethics/4546/subview.do", "https://www.inu.ac.kr/bbs/isis/1161/rssList.do?row=10"),
 
     // 도시과학대학
-    URBAN_ADMINISTRATION("도시행정학과", "https://urban.inu.ac.kr/urban/4920/subview.do"),
-    CIVIL_ENVIRONMENT_ENGINEERING("도시환경학부 (건설환경공학전공)", "https://civil.inu.ac.kr/civil/4707/subview.do"),
-    ENVIRONMENT_ENGINEERING("도시환경학부 (환경공학전공)", "https://et.inu.ac.kr/et/7728/subview.do"),
-    URBAN_ENGINEERING("도시공학과", "https://scity.inu.ac.kr/ucv/4750/subview.do"),
-    URBAN_ARCHITECTURE("도시건축학부", "https://archi.inu.ac.kr/archi/4818/subview.do"),
+    URBAN_ADMINISTRATION("도시행정학과", "https://urban.inu.ac.kr/urban/4920/subview.do", "https://www.inu.ac.kr/bbs/isis/1213/rssList.do?row=10"),
+    CIVIL_ENVIRONMENT_ENGINEERING("도시환경학부 (건설환경공학전공)", "https://civil.inu.ac.kr/civil/4707/subview.do", "https://www.inu.ac.kr/bbs/isis/1237/rssList.do?row=10"),
+    ENVIRONMENT_ENGINEERING("도시환경학부 (환경공학전공)", "https://et.inu.ac.kr/et/7728/subview.do", "https://www.inu.ac.kr/bbs/isis/1267/rssList.do?row=10"),
+    URBAN_ENGINEERING("도시공학과", "https://scity.inu.ac.kr/ucv/4750/subview.do", "https://www.inu.ac.kr/bbs/isis/1252/rssList.do?row=10"),
+    URBAN_ARCHITECTURE("도시건축학부", "https://archi.inu.ac.kr/archi/4818/subview.do", "https://www.inu.ac.kr/bbs/isis/1205/rssList.do?row=10"),
 
     // 생명과학기술대학
-    LIFE_SCIENCE("생명과학부 (생명과학전공)", "https://life.inu.ac.kr/life/4954/subview.do"),
-    LIFE_SCIENCE_MOLECULAR("생명과학부 (분자의생명전공)", "https://molbio.inu.ac.kr/molbio/4999/subview.do"),
-    BIOENGINEERING("생명공학부 (생명공학전공)", "https://bioeng.inu.ac.kr/engineeringlife/5121/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGZW5naW5lZXJpbmdsaWZlJTJGMTI4NSUyRmFydGNsTGlzdC5kbyUzRmJic0NsU2VxJTNEMTYxNiUyNmJic09wZW5XcmRTZXElM0QlMjZpc1ZpZXdNaW5lJTNEZmFsc2UlMjZzcmNoQ29sdW1uJTNEc2olMjZzcmNoV3JkJTNEJTI2"),
-    BIOENGINEERING_NANO("생명공학부 (나노바이오공학전공)", "https://nanobio.inu.ac.kr/nanobio/5070/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGbmFub2JpbyUyRjEyNzklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE2MTIlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D"),
+    LIFE_SCIENCE("생명과학부 (생명과학전공)", "https://life.inu.ac.kr/life/4954/subview.do", "https://www.inu.ac.kr/bbs/isis/1290/rssList.do?row=10"),
+    LIFE_SCIENCE_MOLECULAR("생명과학부 (분자의생명전공)", "https://molbio.inu.ac.kr/molbio/4999/subview.do", "https://www.inu.ac.kr/bbs/isis/1883/rssList.do?row=10", false, true, true),
+    BIOENGINEERING("생명공학부 (생명공학전공)", "https://bioeng.inu.ac.kr/engineeringlife/5121/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGZW5naW5lZXJpbmdsaWZlJTJGMTI4NSUyRmFydGNsTGlzdC5kbyUzRmJic0NsU2VxJTNEMTYxNiUyNmJic09wZW5XcmRTZXElM0QlMjZpc1ZpZXdNaW5lJTNEZmFsc2UlMjZzcmNoQ29sdW1uJTNEc2olMjZzcmNoV3JkJTNEJTI2", "https://www.inu.ac.kr/bbs/isis/1285/rssList.do?row=10"),
+    BIOENGINEERING_NANO("생명공학부 (나노바이오공학전공)", "https://nanobio.inu.ac.kr/nanobio/5070/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGbmFub2JpbyUyRjEyNzklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE2MTIlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D", "https://www.inu.ac.kr/bbs/isis/1279/rssList.do?row=10"),
 
     // 융합자유전공대학
-    LIBERAL_ARTS("자유전공학부", "https://www.inu.ac.kr/clis/12702/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGY2xpcyUyRjI5NjklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE5OTMlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D"),
-    INTERNATIONAL_LIBERAL_ARTS("국제자유전공학부", "https://www.inu.ac.kr/clis/12702/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGY2xpcyUyRjI5NjklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE5OTUlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D"),
-    CONVERGENCE("융합학부", "https://www.inu.ac.kr/clis/12702/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGY2xpcyUyRjI5NjklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE5OTYlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D"),
+    LIBERAL_ARTS("자유전공학부", "https://www.inu.ac.kr/clis/12702/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGY2xpcyUyRjI5NjklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE5OTMlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D", "https://www.inu.ac.kr/bbs/isis/2969/rssList.do?row=10", false, true, true),
+    INTERNATIONAL_LIBERAL_ARTS("국제자유전공학부", "https://www.inu.ac.kr/clis/12702/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGY2xpcyUyRjI5NjklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE5OTUlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D", "https://www.inu.ac.kr/bbs/isis/2969/rssList.do?row=10", false, true, true),
+    CONVERGENCE("융합학부", "https://www.inu.ac.kr/clis/12702/subview.do?enc=Zm5jdDF8QEB8JTJGYmJzJTJGY2xpcyUyRjI5NjklMkZhcnRjbExpc3QuZG8lM0ZiYnNDbFNlcSUzRDE5OTYlMjZiYnNPcGVuV3JkU2VxJTNEJTI2aXNWaWV3TWluZSUzRGZhbHNlJTI2c3JjaENvbHVtbiUzRHNqJTI2c3JjaFdyZCUzRCUyNg%3D%3D", "https://www.inu.ac.kr/bbs/isis/2969/rssList.do?row=10", false, true, true),
 
     // 동북아국제통상학부
-    NORTHEAST_ASIAN_TRADE("동북아국제통상전공", "https://www.inu.ac.kr/nas/3798/subview.do"),
-    SMART_LOGISTICS_ENGINEERING("스마트물류공학전공", "https://slog.inu.ac.kr/slog/3842/subview.do"),
-    IBE("IBE전공", "https://ibe.inu.ac.kr/ibe/3887/subview.do"),
+    NORTHEAST_ASIAN_TRADE("동북아국제통상전공", "https://www.inu.ac.kr/nas/3798/subview.do", "https://www.inu.ac.kr/bbs/isis/1830/rssList.do?row=10", false, true, true),
+    SMART_LOGISTICS_ENGINEERING("스마트물류공학전공", "https://slog.inu.ac.kr/slog/3842/subview.do", "https://www.inu.ac.kr/bbs/isis/1833/rssList.do?row=10", false, true, true),
+    IBE("IBE전공", "https://ibe.inu.ac.kr/ibe/3887/subview.do", "https://www.inu.ac.kr/bbs/isis/1840/rssList.do?row=10", false, true, true),
 
     // 법학부
-    LAW("법학부", "https://law.inu.ac.kr/law/5184/subview.do");
+    LAW("법학부", "https://law.inu.ac.kr/law/5184/subview.do", "https://www.inu.ac.kr/bbs/isis/1299/rssList.do?row=10");
 
     private final String departmentName;
     private final String urls;
+    private final String rssUrl;
+    private final boolean rssSupported;
+    private final boolean serviceAvailable;
+    private final boolean contentAvailable;
+
+    Department(String departmentName, String urls, String rssUrl) {
+        this(departmentName, urls, rssUrl, true, true, true);
+    }
+
+    Department(String departmentName, String urls, String rssUrl, boolean rssSupported, boolean serviceAvailable, boolean contentAvailable) {
+        this.departmentName = departmentName;
+        this.urls = urls;
+        this.rssUrl = rssUrl;
+        this.rssSupported = rssSupported;
+        this.serviceAvailable = serviceAvailable;
+        this.contentAvailable = contentAvailable;
+    }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
@@ -863,6 +863,44 @@ public class NoticeService {
             return null;
         }
 
+        // 1. HTML5 data-* 속성 파싱 (가장 현대적이고 표준화된 방식 지원)
+        String artclSeq = linkElement.attr("data-bbs-artcl-seq").trim();
+        String fnctNo = linkElement.attr("data-fnct-no").trim();
+        String siteId = linkElement.attr("data-site-id").trim();
+
+        if (!artclSeq.isBlank() && !fnctNo.isBlank()) {
+            if (siteId.isBlank()) {
+                siteId = "isis";
+            }
+            try {
+                java.net.URI uri = java.net.URI.create(listUrl);
+                String baseDomain = uri.getScheme() + "://" + uri.getHost();
+                return baseDomain + "/bbs/" + siteId + "/" + fnctNo + "/" + artclSeq + "/artclView";
+            } catch (Exception e) {
+                return "https://www.inu.ac.kr/bbs/" + siteId + "/" + fnctNo + "/" + artclSeq + "/artclView";
+            }
+        }
+
+        // 2. onclick 자바스크립트 함수 인자 파싱 (폴백 처리)
+        String onclick = linkElement.attr("onclick").trim();
+        if (!onclick.isBlank()) {
+            // fn_artclView('376', '424693') 또는 fn_egov_inqire_notice('123', '456') 형태 매칭
+            java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("['\"](\\d+)['\"]\\s*,\\s*['\"](\\d+)['\"]");
+            java.util.regex.Matcher matcher = pattern.matcher(onclick);
+            if (matcher.find()) {
+                String extractedBbsSeq = matcher.group(1);
+                String extractedArtclSeq = matcher.group(2);
+                try {
+                    java.net.URI uri = java.net.URI.create(listUrl);
+                    String baseDomain = uri.getScheme() + "://" + uri.getHost();
+                    return baseDomain + "/bbs/isis/" + extractedBbsSeq + "/" + extractedArtclSeq + "/artclView";
+                } catch (Exception e) {
+                    return "https://www.inu.ac.kr/bbs/isis/" + extractedBbsSeq + "/" + extractedArtclSeq + "/artclView";
+                }
+            }
+        }
+
+        // 3. 기존의 정적 href 파싱 폴백
         if (useAbsoluteHref) {
             String absoluteHref = linkElement.attr("abs:href");
             if (!absoluteHref.isBlank()) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.inuappcenterportal.inuportal.domain.keyword.service.KeywordService;
 import kr.inuappcenterportal.inuportal.domain.notice.dto.DepartmentNoticeListResponse;
+import kr.inuappcenterportal.inuportal.domain.notice.dto.DepartmentNoticePageResponse;
 import kr.inuappcenterportal.inuportal.domain.notice.dto.NoticeListResponseDto;
 import kr.inuappcenterportal.inuportal.domain.notice.enums.Department;
 import kr.inuappcenterportal.inuportal.domain.notice.enums.DepartmentNoticeContentStatus;
@@ -392,7 +393,93 @@ public class NoticeService {
     public void crawlingDepartmentNotices(Department[] departments, int start, int end) {
         for (int i = start; i < end; i++) {
             Department department = departments[i];
-            getNoticeByDepartment(department, getDepartmentCrawlConfig(department));
+            if (!department.isServiceAvailable()) {
+                continue;
+            }
+            if (department.isRssSupported()) {
+                syncDepartmentNoticeByRss(department);
+            } else {
+                getNoticeByDepartment(department, getDepartmentCrawlConfig(department));
+            }
+        }
+    }
+
+    private void syncDepartmentNoticeByRss(Department department) {
+        try {
+            log.info("[학과공지 RSS] 동기화 시작: department={}, rssUrl={}", department.name(), department.getRssUrl());
+
+            Document document = Jsoup.connect(department.getRssUrl())
+                    .userAgent(CRAWLER_USER_AGENT)
+                    .timeout(REQUEST_TIMEOUT_MILLIS)
+                    .parser(org.jsoup.parser.Parser.xmlParser())
+                    .get();
+
+            Elements items = document.select("item");
+            int newCount = 0;
+            int updateCount = 0;
+
+            for (Element item : items) {
+                String title = item.select("title").text().trim();
+                String rawLink = item.select("link").text().trim();
+                if (rawLink.isBlank()) {
+                    continue;
+                }
+                String link = resolveRelativeUrl(department.getUrls(), null, rawLink);
+
+                String pubDateStr = item.select("pubDate").text().trim();
+                String parsedRssDate = parseRssDate(pubDateStr);
+                LocalDate date = parseDepartmentNoticeDate(parsedRssDate);
+                
+                long views = 0L;
+                String viewsStr = item.select("hit").text().trim();
+                if (!viewsStr.isBlank()) {
+                    try {
+                        views = Long.parseLong(viewsStr);
+                    } catch (Exception e) {
+                        // ignore
+                    }
+                }
+
+                Optional<DepartmentNotice> existingNotice = departmentNoticeRepository.findFirstByDepartmentAndUrl(department, link);
+                if (existingNotice.isEmpty()) {
+                    existingNotice = departmentNoticeRepository.findFirstByDepartmentAndTitleAndCreateDate(department, title, date);
+                }
+
+                DepartmentNotice departmentNotice;
+                boolean isNewNotice = false;
+
+                if (existingNotice.isPresent()) {
+                    departmentNotice = existingNotice.get();
+                    departmentNotice.updateListing(title, date, views, link);
+                    updateCount++;
+                } else {
+                    departmentNotice = departmentNoticeRepository.save(
+                            DepartmentNotice.create(department, title, date, views, link)
+                    );
+                    isNewNotice = true;
+                    newCount++;
+                }
+
+                syncDepartmentNoticeContent(departmentNotice, getDepartmentCrawlConfig(department));
+
+                if (isNewNotice) {
+                    if (TransactionSynchronizationManager.isActualTransactionActive()) {
+                        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                            @Override
+                            public void afterCommit() {
+                                scheduleExtractService.extractScheduleAsync(departmentNotice, true);
+                            }
+                        });
+                    } else {
+                        scheduleExtractService.extractScheduleAsync(departmentNotice, true);
+                    }
+                }
+            }
+
+            log.info("[학과공지 RSS] 동기화 완료: department={}, 신규={}, 업데이트={}", department.name(), newCount, updateCount);
+
+        } catch (Exception e) {
+            log.error("[학과공지 RSS] 크롤링 중 에러 발생: department={}, message={}", department.name(), e.getMessage());
         }
     }
 
@@ -525,6 +612,10 @@ public class NoticeService {
                     String dateStr = ele.select(config.getDateSelector()).text();
                     LocalDate date = parseDepartmentNoticeDate(dateStr);
                     String href = resolveDepartmentNoticeUrl(ele.selectFirst(config.getLinkSelector()), url, config.isUseAbsoluteHref());
+                    if (href == null) {
+                        log.warn("학과 공지 상세 링크(href) 수집 실패: title={}", title);
+                        continue;
+                    }
                     long views = parseLongValue(ele.select(config.getViewsSelector()).text());
 
                     Optional<DepartmentNotice> existingDepartmentNotice = departmentNoticeRepository.findFirstByDepartmentAndUrl(department, href);
@@ -576,6 +667,11 @@ public class NoticeService {
     }
 
     private void syncDepartmentNoticeContent(DepartmentNotice departmentNotice, DepartmentCrawlConfig config) {
+        if (!departmentNotice.getDepartment().isContentAvailable()) {
+            departmentNotice.markNoTextContent();
+            return;
+        }
+
         if (departmentNotice.isContentCrawlBlocked() && departmentNotice.hasContentCrawlMetadata()) {
             return;
         }
@@ -764,7 +860,7 @@ public class NoticeService {
 
     private String resolveDepartmentNoticeUrl(Element linkElement, String listUrl, boolean useAbsoluteHref) {
         if (linkElement == null) {
-            return listUrl;
+            return null;
         }
 
         if (useAbsoluteHref) {
@@ -774,9 +870,9 @@ public class NoticeService {
             }
         }
 
-        String rawHref = linkElement.attr("href");
-        if (rawHref == null || rawHref.isBlank()) {
-            return listUrl;
+        String rawHref = linkElement.attr("href").trim();
+        if (rawHref.isBlank() || "#".equals(rawHref) || "#none".equals(rawHref) || rawHref.startsWith("javascript:")) {
+            return null;
         }
         if (rawHref.startsWith("http://") || rawHref.startsWith("https://")) {
             return rawHref;
@@ -958,20 +1054,24 @@ public class NoticeService {
     }
 
     @Transactional(readOnly = true)
-    public ListResponseDto<DepartmentNoticeListResponse> getDepartmentNotices(Department department, String sort, int page) {
+    public DepartmentNoticePageResponse getDepartmentNotices(Department department, String sort, int page) {
         Pageable pageable = PageRequest.of(page > 0 ? --page : page, 8, sort(sort));
         Page<DepartmentNotice> departmentNotices = departmentNoticeRepository.findAllByDepartment(department, pageable);
         Map<Long, Boolean> hasSchedulesMap = loadHasSchedulesMap(departmentNotices.getContent());
 
-        return ListResponseDto.of(
+        List<DepartmentNoticeListResponse> contents = departmentNotices.getContent().stream()
+                .map(notice -> DepartmentNoticeListResponse.of(
+                        notice,
+                        hasSchedulesMap.getOrDefault(notice.getId(), false)
+                ))
+                .collect(Collectors.toList());
+
+        return DepartmentNoticePageResponse.of(
                 departmentNotices.getTotalPages(),
                 departmentNotices.getTotalElements(),
-                departmentNotices.getContent().stream()
-                        .map(notice -> DepartmentNoticeListResponse.of(
-                                notice,
-                                hasSchedulesMap.getOrDefault(notice.getId(), false)
-                        ))
-                        .collect(Collectors.toList())
+                contents,
+                department.isServiceAvailable(),
+                department.isContentAvailable()
         );
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/notice/service/NoticeService.java
@@ -426,6 +426,28 @@ public class NoticeService {
                 }
                 String link = resolveRelativeUrl(department.getUrls(), null, rawLink);
 
+                // 중앙 RSS의 가상 경로(/bbs/isis/)를 학과의 진짜 식별자 경로(/bbs/실제학과명/)로 동적 치환하여 404 차단
+                String siteId = "isis";
+                try {
+                    java.net.URI uri = java.net.URI.create(department.getUrls());
+                    String path = uri.getPath();
+                    if (path != null && path.startsWith("/")) {
+                        String[] segments = path.split("/");
+                        for (String segment : segments) {
+                            if (!segment.isBlank()) {
+                                siteId = segment;
+                                break;
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // fallback to "isis"
+                }
+
+                if (link.contains("/bbs/isis/")) {
+                    link = link.replace("/bbs/isis/", "/bbs/" + siteId + "/");
+                }
+
                 String pubDateStr = item.select("pubDate").text().trim();
                 String parsedRssDate = parseRssDate(pubDateStr);
                 LocalDate date = parseDepartmentNoticeDate(parsedRssDate);


### PR DESCRIPTION
## 📎 관련 이슈

- closed #234 

## 📄 설명

1. 학과별 상태 분류 및 메타데이터 추가

Department enum에 rssUrl, isRssSupported, isServiceAvailable, isContentAvailable 필드를 추가

2. 프론트엔드 연동용 신규 DTO 도입

프론트엔드에서 학과의 상태 플래그(isServiceAvailable, isContentAvailable)를 읽을 수 있도록, 해당 API 전용의 DepartmentNoticePageResponse DTO를 신규 정의하여 호환성 유지하면서 필드 추가

3. RSS에서 제공한 링크가 부정확한 경우 보정


## 🤔 추후 작업 사항

- ex) 성능 개선 필요