### PR TITLE
✅ test: CourseService 테스트 컨텍스트 범위 축소

### DIFF
--- a/src/test/java/kr/inuappcenterportal/inuportal/course/CourseServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/course/CourseServiceTest.java
@@ -11,15 +11,17 @@ import kr.inuappcenterportal.inuportal.domain.department.enums.Department;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@Transactional
+@DataJpaTest
+@Import(CourseService.class)
+@ActiveProfiles("test")
 public class CourseServiceTest {
 
     @Autowired
@@ -48,7 +50,7 @@ public class CourseServiceTest {
         assertThat(course.getContent()).isEqualTo("운영체제 설명");
         assertThat(course.isActive()).isTrue();
     }
-    
+
 
     @Test
     @DisplayName("이미 존재하는 강의는 크롤링된 값으로 수정한다")


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- FirebaseConfig, LocalFirebaseConfig의 @Profile("!test") 어노테이션이 달려있어서 전혀 다른 기능이지만 이것때문에 기존 테스트 코드가 동작하지 않는 문제가 발생
- 따라서 모든 빈을 띄우는 기존 @SpringBootTest 통합 테스트에서 테스트 코드에서 검증하고자 하는 JPA 관련 Bean + CourseService만 띄우는 @DataJpaTest + @Import(CourseService.class) 으로 테스트 범위 축소

## 🤔 추후 작업 사항

- ex) 성능 개선 필요