### PR TITLE
✨ feat: 학기 생성을 위한 년단위 학사일정 크롤링 기능 개발

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/controller/CourseController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/controller/CourseController.java
@@ -6,7 +6,6 @@ import kr.inuappcenterportal.inuportal.domain.course.service.CourseService;
 import kr.inuappcenterportal.inuportal.domain.department.enums.Department;
 import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,8 +28,9 @@ public class CourseController implements CourseApiSpecification {
     ) {
         Department parsedDepartment = Department.from(department);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(ResponseDto.of(courseService.getCourses(parsedDepartment), "강의 목록 조회 성공"));
+        return ResponseEntity.ok(
+                ResponseDto.of(courseService.getCourses(parsedDepartment), "강의 목록 조회 성공")
+        );
     }
 
     /**

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/crawler/CourseOverviewParser.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/crawler/CourseOverviewParser.java
@@ -12,9 +12,23 @@ import java.util.List;
 @Component
 public class CourseOverviewParser {
     public List<CourseOverviewItemDto> parse(Document document) {
+        List<CourseOverviewItemDto> result = new ArrayList<>();
+
+        result.addAll(parseHBoxOverview(document));
+        result.addAll(parseListOverview(document));
+        result.addAll(parseCurTableOverview(document));
+
+        return result;
+    }
+
+    /**
+     * hBox6 파싱 로직
+     * (대부분의 학과가 여기에 포함)
+     */
+    private List<CourseOverviewItemDto> parseHBoxOverview(Document document) {
         Elements items = document.select("ul.hBox6 > li");
 
-        List<CourseOverviewItemDto> courseOverviewItems = new ArrayList<>();
+        List<CourseOverviewItemDto> result = new ArrayList<>();
 
         for (Element item : items) {
             String title = item.select(".tit1").text();
@@ -34,9 +48,191 @@ public class CourseOverviewParser {
                 continue;
             }
 
-            courseOverviewItems.add(new CourseOverviewItemDto(title, content));
+            result.add(new CourseOverviewItemDto(title, content));
         }
 
-        return courseOverviewItems;
+        return result;
     }
+
+    /**
+     * list 파싱 로직
+     * (바이오-로봇 시스템공학과 이 로직에 해당)
+     */
+    private List<CourseOverviewItemDto> parseListOverview(Document document) {
+        Elements items = document.select("ul.list_1 > li");
+
+        List<CourseOverviewItemDto> result = new ArrayList<>();
+
+        for (Element item : items) {
+            Element titleElement = item.clone();
+            titleElement.select("ul.list_3").remove();
+
+            String title = clean(titleElement.text());
+            String content = clean(item.select("ul.list_3 > li").text());
+
+            if (title.isBlank() || content.isBlank()) {
+                continue;
+            }
+
+            result.add(new CourseOverviewItemDto(title, content));
+        }
+
+        return result;
+    }
+
+    private List<CourseOverviewItemDto> parseCurTableOverview(Document document) {
+        List<CourseOverviewItemDto> result = new ArrayList<>();
+
+        for (Element table : document.select("table.curTable")) {
+            int titleIndex = findTitleIndexFromHeader(table);
+
+            if (titleIndex < 0) {
+                continue;
+            }
+
+            Elements rows = table.select("tbody > tr");
+
+            for (int i = 0; i < rows.size(); i++) {
+                Element row = rows.get(i);
+
+                if (isDescriptionRow(row)) {
+                    continue;
+                }
+
+                String title = getCellText(row, titleIndex);
+                Element descriptionRow = findNextDescriptionRow(rows, i);
+                String content = extractDescriptionContent(descriptionRow);
+
+                if (title.isBlank() || content.isBlank()) {
+                    continue;
+                }
+
+                result.add(new CourseOverviewItemDto(title, content));
+            }
+        }
+
+        return result;
+    }
+
+    private int findTitleIndexFromHeader(Element table) {
+        for (Element row : table.select("thead tr")) {
+            List<String> headers = expandRowCells(row);
+
+            for (int i = 0; i < headers.size(); i++) {
+                String header = compact(headers.get(i));
+
+                if (isTitleHeader(header)) {
+                    return i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private boolean isTitleHeader(String header) {
+        if (header.contains("코드")) {
+            return false;
+        }
+
+        return header.contains("교과목명")
+                || header.contains("과목명")
+                || header.equals("교과목");
+    }
+
+    private List<String> expandRowCells(Element row) {
+        List<String> values = new ArrayList<>();
+
+        for (Element cell : directCells(row)) {
+            String text = clean(cell.text());
+            int colspan = parseSpan(cell.attr("colspan"));
+
+            for (int i = 0; i < colspan; i++) {
+                values.add(text);
+            }
+        }
+
+        return values;
+    }
+
+    private String getCellText(Element row, int index) {
+        Elements cells = directCells(row);
+
+        if (index < 0 || index >= cells.size()) {
+            return "";
+        }
+
+        return clean(cells.get(index).text());
+    }
+
+    private Element findNextDescriptionRow(Elements rows, int currentIndex) {
+        if (currentIndex + 1 >= rows.size()) {
+            return null;
+        }
+
+        Element nextRow = rows.get(currentIndex + 1);
+
+        return isDescriptionRow(nextRow) ? nextRow : null;
+    }
+
+    private boolean isDescriptionRow(Element row) {
+        return row != null
+                && row.text().contains("강의설명")
+                && row.selectFirst("p") != null;
+    }
+
+    private String extractDescriptionContent(Element row) {
+        if (row == null) {
+            return "";
+        }
+
+        String content = row.select("p").text();
+
+        if (content.isBlank()) {
+            content = row.text().replace("강의설명", "");
+        }
+
+        return clean(content);
+    }
+
+    private Elements directCells(Element row) {
+        Elements cells = new Elements();
+
+        for (Element child : row.children()) {
+            if (child.normalName().equals("th") || child.normalName().equals("td")) {
+                cells.add(child);
+            }
+        }
+
+        return cells;
+    }
+
+    private int parseSpan(String value) {
+        if (value == null || value.isBlank()) {
+            return 1;
+        }
+
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 1;
+        }
+    }
+
+    private String clean(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value
+                .replace("\"", "")
+                .replace("\u00a0", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+    private String compact(String value) {
+        return clean(value).replace(" ", "");
+    }
+
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/crawler/CurriculumParser.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/crawler/CurriculumParser.java
@@ -84,10 +84,10 @@ public class CurriculumParser {
             List<String> headers = matrix.get(headerRowIndex);
 
             return new ColumnIndexes(
-                    findHeaderIndex(headers, "학년", "이수학년", "수강대상학년"),
+                    findGradeHeaderIndex(headers),
                     findHeaderIndex(headers, "학기", "편성학기", "개설학기", "수강대상학기"),
                     findHeaderIndex(headers, "이수구분", "구분", "이수영역", "영역"),
-                    findHeaderIndex(headers, "교과목명", "과목명", "교과목"),
+                    findTitleHeaderIndex(headers),
                     findHeaderIndex(headers, "학점", "학점수"),
                     headerRowIndex + 1
             );
@@ -125,10 +125,10 @@ public class CurriculumParser {
 
         fields = dropCaptionPrefix(fields);
 
-        int gradeIndex = findHeaderIndex(fields, "학년", "이수학년", "수강대상학년");
+        int gradeIndex = findGradeHeaderIndex(fields);
         int termIndex = findHeaderIndex(fields, "학기", "편성학기", "개설학기", "수강대상학기");
         int divisionIndex = findHeaderIndex(fields, "이수구분", "구분", "이수영역", "영역");
-        int titleIndex = findHeaderIndex(fields, "교과목명", "과목명", "교과목");
+        int titleIndex = findTitleHeaderIndex(fields);
         int creditIndex = findHeaderIndex(fields, "학점", "학점수");
 
         return new ColumnIndexes(gradeIndex, termIndex, divisionIndex, titleIndex, creditIndex, 0);
@@ -263,7 +263,7 @@ public class CurriculumParser {
         for (int i = 0; i < matrix.size(); i++) {
             List<String> row = matrix.get(i);
 
-            boolean hasTitle = findHeaderIndex(row, "교과목명", "과목명", "교과목") >= 0;
+            boolean hasTitle = findTitleHeaderIndex(row) >= 0;
             boolean hasTerm = findHeaderIndex(row, "학기", "편성학기", "개설학기", "수강대상학기") >= 0;
             boolean hasCredit = findHeaderIndex(row, "학점", "학점수") >= 0;
             boolean hasDivision = findHeaderIndex(row, "이수구분", "구분", "이수영역", "영역") >= 0;
@@ -290,20 +290,123 @@ public class CurriculumParser {
         return -1;
     }
 
+    private int findGradeHeaderIndex(List<String> headers) {
+        for (int i = 0; i < headers.size(); i++) {
+            String header = compact(headers.get(i));
+
+            if (header.equals("학년")
+                    || header.equals("이수학년")
+                    || header.equals("수강대상학년")) {
+                return i;
+            }
+        }
+
+        for (int i = 0; i < headers.size(); i++) {
+            String header = compact(headers.get(i));
+
+            if (header.contains("입학")
+                    || header.contains("년도")
+                    || header.contains("연도")) {
+                continue;
+            }
+
+            if (header.contains("학년")) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private int findTitleHeaderIndex(List<String> headers) {
+        for (int i = 0; i < headers.size(); i++) {
+            String header = compact(headers.get(i));
+
+            if (header.contains("코드")) {
+                continue;
+            }
+
+            if (header.contains("교과목명")
+                    || header.contains("과목명")
+                    || header.equals("교과목")) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
     private String findGradeFromSection(Element table) {
         Element current = table;
 
         while (current != null) {
+            String grade = findGradeFromElementId(current);
+            if (!grade.isBlank()) {
+                return grade;
+            }
+
+            grade = findGradeFromHeading(current);
+            if (!grade.isBlank()) {
+                return grade;
+            }
+
             String id = current.id();
 
             if (!id.isBlank()) {
-                String grade = findGradeAnchorText(current.ownerDocument(), id);
+                grade = findGradeAnchorText(current.ownerDocument(), id);
                 if (!grade.isBlank()) {
                     return grade;
                 }
             }
 
             current = current.parent();
+        }
+
+        return "";
+    }
+
+    private String findGradeFromHeading(Element element) {
+        Element heading = element.selectFirst("> h2");
+
+        if (heading != null) {
+            String grade = parseGradeHeadingText(heading.text());
+            if (!grade.isBlank()) {
+                return grade;
+            }
+        }
+
+        Element sibling = element.previousElementSibling();
+        while (sibling != null) {
+            heading = sibling.selectFirst("h2");
+
+            if (heading != null) {
+                String grade = parseGradeHeadingText(heading.text());
+                if (!grade.isBlank()) {
+                    return grade;
+                }
+            }
+
+            sibling = sibling.previousElementSibling();
+        }
+
+        return "";
+    }
+
+    private String parseGradeHeadingText(String value) {
+        String grade = normalizeGrade(value);
+
+        if (grade.matches("\\d학년") || grade.equals("공통")) {
+            return grade;
+        }
+
+        return "";
+    }
+
+    private String findGradeFromElementId(Element element) {
+        String id = element.id();
+
+        if (id.matches("curr-0[1-4]")) {
+            return id.substring(id.length() - 1) + "학년";
         }
 
         return "";
@@ -436,6 +539,7 @@ public class CurriculumParser {
         return compactTitle.equals("교과목명")
                 || compactTitle.equals("과목명")
                 || compactTitle.equals("교과목")
+                || compactTitle.contains("강의설명")
                 || compactTitle.contains("소계")
                 || compactTitle.contains("합계");
     }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/enums/CompletionDivision.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/enums/CompletionDivision.java
@@ -23,7 +23,9 @@ public enum CompletionDivision {
 
     EDUCATION("교직", "교직"),
     MILITARY("군사학", "군사학"),
-    SELECT_COMMON("일반선택", "일선");
+    SELECT_COMMON("일반선택", "일선"),
+
+    UNKNOWN("알 수 없는 값", "알 수 없음");
 
 
     private final String description;
@@ -41,6 +43,6 @@ public enum CompletionDivision {
             }
         }
 
-        throw new IllegalArgumentException("지원하지 않는 이수구분입니다. value=" + value);
+        return UNKNOWN;
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/enums/TargetGrade.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/enums/TargetGrade.java
@@ -11,7 +11,7 @@ public enum TargetGrade {
     SECOND("2학년"),
     THIRD("3학년"),
     FOURTH("4학년"),
-    UNKNOWN("미정");
+    UNKNOWN("알 수 없음");
 
     private final String displayName;
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/enums/TargetTerm.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/enums/TargetTerm.java
@@ -9,7 +9,7 @@ public enum TargetTerm {
     FIRST("1학기"),
     SECOND("2학기"),
     COMMON("공통"),
-    UNKNOWN("미정");
+    UNKNOWN("알 수 없음");
 
     private final String displayName;
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseService.java
@@ -117,12 +117,7 @@ public class CourseService {
             return null;
         }
 
-        try {
-            return CompletionDivision.from(value);
-        } catch (IllegalArgumentException e) {
-            log.warn("지원하지 않는 이수구분입니다. value={}", value);
-            return null;
-        }
+        return CompletionDivision.from(value);
     }
 
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/department/enums/Department.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/department/enums/Department.java
@@ -138,7 +138,7 @@ public enum Department {
             "https://uipa10.inu.ac.kr/uipa10/3951/subview.do",
             "https://uipa10.inu.ac.kr/uipa10/3950/subview.do"),
     SPORTS_SCIENCE("스포츠과학부", College.COLLEGE_OF_ARTS_AND_PHYSICAL_EDUCATION,
-            null,
+            "https://sports.inu.ac.kr/sub3_2.php",
             "https://sports.inu.ac.kr/sub3_2.php"),
     HEALTH_EXERCISE("운동건강학부", College.COLLEGE_OF_ARTS_AND_PHYSICAL_EDUCATION,
             "https://uiex.inu.ac.kr/uiex/4060/subview.do",

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/controller/SemesterApiSpecification.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/controller/SemesterApiSpecification.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import kr.inuappcenterportal.inuportal.domain.semester.dto.SemesterResponseDto;
+import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
@@ -18,17 +19,17 @@ public interface SemesterApiSpecification {
 
     @Operation(
             summary = "학기 조회",
-            description = "유효한 학기 조회합니다."
+            description = "학기를 조회합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "유효한 학기 조회 성공",
+                    description = "학기 조회 성공",
                     content = @Content(
                             mediaType = "application/json",
                             array = @ArraySchema(schema = @Schema(implementation = SemesterResponseDto.class)),
                             examples = @ExampleObject(
-                                    name = "유효한 Semester 조회 응답 예시",
+                                    name = "Semester 조회 응답 예시",
                                     value = """
                                             [
                                               {
@@ -47,11 +48,12 @@ public interface SemesterApiSpecification {
                                                 "startDate": "2026-06-22",
                                                 "endDate": "2026-07-12"
                                               }
-                                            ]
+                                            ],
+                                            "msg": "학기 조회 성공"
                                             """
                             )
                     )
             )}
     )
-    ResponseEntity<List<SemesterResponseDto>> getValidSemesters();
+    ResponseEntity<ResponseDto<List<SemesterResponseDto>>> getSemesters();
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/controller/SemesterController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/controller/SemesterController.java
@@ -20,12 +20,14 @@ public class SemesterController implements SemesterApiSpecification {
     private final SemesterService semesterService;
 
     /**
-     * 유효한 학기 조회 메서드(Open, Closed)
+     * 학기 조회 메서드
      */
     @GetMapping
-    public ResponseEntity<List<SemesterResponseDto>> getValidSemesters() {
-        List<SemesterResponseDto> semesters = semesterService.getValidSemesters();
-        return ResponseEntity.ok(semesters);
+    public ResponseEntity<ResponseDto<List<SemesterResponseDto>>> getSemesters() {
+        List<SemesterResponseDto> semesters = semesterService.getSemesters();
+        return ResponseEntity.ok(
+                ResponseDto.of(semesters, "학기 조회 성공")
+        );
     }
 
     /**

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/service/SemesterService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/service/SemesterService.java
@@ -30,9 +30,9 @@ public class SemesterService {
      * 만들어진 학기 조회 메서드
      */
     @Transactional(readOnly = true)
-    public List<SemesterResponseDto> getValidSemesters() {
+    public List<SemesterResponseDto> getSemesters() {
         return semesterRepository.findAllByStatusInOrderByYearDescTermAsc(
-                        List.of(SemesterStatus.OPEN, SemesterStatus.CLOSED)
+                        List.of(SemesterStatus.OPEN, SemesterStatus.CLOSED, SemesterStatus.UPCOMING)
                 )
                 .stream()
                 .map(SemesterResponseDto::from)


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- 로컬에서 학사일정이 크롤링이 안돼서 학기 생성이 안되는줄 알았는데 dev DB로 보니까 정상적으로 학기가 생성되서 전체 학기 조회로 바꿈
- 추가로 기존에 파싱안되면 예외 학과들에 대한 파싱로직을 추가

## 🤔 추후 작업 사항

- ex) 성능 개선 필요