### PR TITLE
feat: 알림 탭 기능 구현을 위한 fcm 페이로드 추가

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/councilNotice/service/CouncilNoticeService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/councilNotice/service/CouncilNoticeService.java
@@ -44,7 +44,7 @@ public class CouncilNoticeService {
             imageService.saveImageWithThumbnail(councilNotice.getId(),images,path);
         }
         String title = councilNoticeRequestDto.getTitle();
-        fcmService.noticeAll(title);
+        fcmService.noticeAll(title, councilNotice.getId());
         return councilNotice.getId();
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
@@ -50,6 +50,12 @@ public class FcmAsyncService {
     }
 
     @Async("messageExecutor")
+    public void sendAsyncTrackedNotification(List<Long> memberIds, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType type, Long targetId, String path) {
+        FcmService.TrackedNotificationDispatch dispatch = fcmService.prepareTrackedNotification(memberIds, title, body, type, targetId, path);
+        fcmService.dispatchTrackedNotification(dispatch);
+    }
+
+    @Async("messageExecutor")
     public void sendAsyncUntrackedNotification(List<Long> memberIds, String title, String body) {
         fcmService.sendUntrackedNotification(memberIds, title, body);
     }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmAsyncService.java
@@ -27,6 +27,12 @@ public class FcmAsyncService {
     }
 
     @Async("messageExecutor")
+    public void sendAsyncKeywordNotice(Map<String, Long> tokenAndMemberId, String title, String body, kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType fcmMessageType, Long targetId, String path) {
+        Long fcmMessageId = fcmService.prepareKeywordNotice(tokenAndMemberId, title, body, fcmMessageType, targetId);
+        fcmService.dispatchKeywordNotice(fcmMessageId, tokenAndMemberId, title, body, fcmMessageType, targetId, path);
+    }
+
+    @Async("messageExecutor")
     public void sendAsyncToMembers(AdminNotificationDispatch dispatch) {
         fcmService.sendToMembers(dispatch);
     }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -167,7 +167,13 @@ public class FcmService {
     @Transactional
     @Async("messageExecutor")
     public void noticeAll(String title) {
-        com.google.firebase.messaging.Message message = com.google.firebase.messaging.Message.builder()
+        noticeAll(title, null);
+    }
+
+    @Transactional
+    @Async("messageExecutor")
+    public void noticeAll(String title, Long councilNoticeId) {
+        com.google.firebase.messaging.Message.Builder messageBuilder = com.google.firebase.messaging.Message.builder()
                 .setTopic("notice")
                 .setNotification(
                         Notification.builder()
@@ -175,8 +181,13 @@ public class FcmService {
                                 .setBody(title)
                                 .build()
                 )
-                .putData("type", "GENERAL")
-                .build();
+                .putData("type", "GENERAL");
+        // 라우팅 정보는 data 블록에만 포함 (총학 공지 상세는 query string ?id= 형태)
+        if (councilNoticeId != null) {
+            messageBuilder.putData("targetId", String.valueOf(councilNoticeId));
+            messageBuilder.putData("path", "/councilnoticedetail?id=" + councilNoticeId);
+        }
+        com.google.firebase.messaging.Message message = messageBuilder.build();
         try {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
@@ -379,6 +390,11 @@ public class FcmService {
      */
     @Transactional
     public TrackedNotificationDispatch prepareTrackedNotification(List<Long> memberIds, String title, String body, FcmMessageType type, Long targetId) {
+        return prepareTrackedNotification(memberIds, title, body, type, targetId, null);
+    }
+
+    @Transactional
+    public TrackedNotificationDispatch prepareTrackedNotification(List<Long> memberIds, String title, String body, FcmMessageType type, Long targetId, String path) {
         if (memberIds == null || memberIds.isEmpty()) {
             return null;
         }
@@ -395,7 +411,7 @@ public class FcmService {
         FcmMessage fcmMessage = saveTrackedMessage(title, body, false, tokenAndMemberId.size(), targetId);
         batchInsertMemberFcmMessages(fcmMessage.getId(), memberIds, type);
 
-        return new TrackedNotificationDispatch(fcmMessage.getId(), tokenAndMemberId, title, body, type, targetId);
+        return new TrackedNotificationDispatch(fcmMessage.getId(), tokenAndMemberId, title, body, type, targetId, path);
     }
 
     public void dispatchTrackedNotification(TrackedNotificationDispatch dispatch) {
@@ -403,7 +419,7 @@ public class FcmService {
             return;
         }
         if (!dispatch.tokenAndMemberId().isEmpty()) {
-            DeliveryResult deliveryResult = dispatchToMembersInternal(dispatch.fcmMessageId(), dispatch.tokenAndMemberId(), dispatch.title(), dispatch.body(), dispatch.type(), dispatch.targetId());
+            DeliveryResult deliveryResult = dispatchToMembersInternal(dispatch.fcmMessageId(), dispatch.tokenAndMemberId(), dispatch.title(), dispatch.body(), dispatch.type(), dispatch.targetId(), dispatch.path());
             fcmTransactionService.updateFinalStatus(dispatch.fcmMessageId(), deliveryResult.successCount(), deliveryResult.failureCount());
         } else {
             fcmTransactionService.updateFinalStatus(dispatch.fcmMessageId(), 0, 0);
@@ -543,6 +559,8 @@ public class FcmService {
                 // 웹뷰에서 라우팅할 때 참조할 공통 데이터 페이로드
                 .putData("type", "CHAT")
                 .putData("chatRoomId", roomIdStr)
+                // 라우팅 정보는 data 블록에만 포함 (채팅방은 path param 형태)
+                .putData("path", "/chat/" + roomIdStr)
                 .setAndroidConfig(AndroidConfig.builder()
                         .setNotification(androidNotiBuilder.build())
                         .build())
@@ -684,7 +702,8 @@ public class FcmService {
             String title,
             String body,
             FcmMessageType type,
-            Long targetId
+            Long targetId,
+            String path
     ) {
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -207,10 +207,14 @@ public class FcmService {
     }
 
     public void dispatchKeywordNotice(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType type, Long targetId) {
+        dispatchKeywordNotice(fcmMessageId, tokenAndMemberId, title, body, type, targetId, null);
+    }
+
+    public void dispatchKeywordNotice(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType type, Long targetId, String path) {
         if (fcmMessageId == null || tokenAndMemberId.isEmpty()) {
             return;
         }
-        DeliveryResult deliveryResult = dispatchToMembersInternal(fcmMessageId, tokenAndMemberId, title, body, type, targetId);
+        DeliveryResult deliveryResult = dispatchToMembersInternal(fcmMessageId, tokenAndMemberId, title, body, type, targetId, path);
         fcmTransactionService.updateFinalStatus(fcmMessageId, deliveryResult.successCount(), deliveryResult.failureCount());
     }
 
@@ -293,6 +297,10 @@ public class FcmService {
     }
 
     private DeliveryResult dispatchToMembersInternal(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType type, Long targetId) {
+        return dispatchToMembersInternal(fcmMessageId, tokenAndMemberId, title, body, type, targetId, null);
+    }
+
+    private DeliveryResult dispatchToMembersInternal(Long fcmMessageId, Map<String, Long> tokenAndMemberId, String title, String body, FcmMessageType type, Long targetId, String path) {
         List<String> tokens = new ArrayList<>(tokenAndMemberId.keySet());
         int batchSize = 500;
         int successCount = 0;
@@ -300,7 +308,7 @@ public class FcmService {
 
         for (int i = 0; i < tokens.size(); i += batchSize) {
             List<String> batchTokens = tokens.subList(i, Math.min(i + batchSize, tokens.size()));
-            MulticastMessage message = createMulticastMessage(batchTokens, title, body, type, targetId);
+            MulticastMessage message = createMulticastMessage(batchTokens, title, body, type, targetId, path);
 
             int batchSuccess = 0;
             int batchFailure = 0;
@@ -439,6 +447,12 @@ public class FcmService {
     }
 
     private MulticastMessage createMulticastMessage(List<String> tokens, String title, String body, FcmMessageType type, Long targetId) {
+        return createMulticastMessage(tokens, title, body, type, targetId, null);
+    }
+
+    private MulticastMessage createMulticastMessage(List<String> tokens, String title, String body, FcmMessageType type, Long targetId, String path) {
+        // notification(title, body)과 data를 항상 함께 발송한다 (data-only 발송 금지)
+        // Android 백그라운드 노출 및 포그라운드 배너 표시를 위해 두 블록이 모두 필요하다
         MulticastMessage.Builder builder = MulticastMessage.builder()
                 .addAllTokens(tokens)
                 .setNotification(Notification.builder()
@@ -451,11 +465,15 @@ public class FcmService {
         }
         if (targetId != null) {
             builder.putData("targetId", String.valueOf(targetId));
-            
+
             // 공지사항인 경우 noticeId로도 탑재해 주어 클라이언트 편의 제공
             if (type == FcmMessageType.SCHOOL_NOTICE || type == FcmMessageType.DEPARTMENT) {
                 builder.putData("noticeId", String.valueOf(targetId));
             }
+        }
+        // 라우팅 정보는 클라이언트가 data 블록에서만 판단하므로 notification에는 넣지 않는다
+        if (path != null && !path.isBlank()) {
+            builder.putData("path", path);
         }
         return builder.build();
     }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/keyword/service/KeywordService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/keyword/service/KeywordService.java
@@ -101,8 +101,8 @@ public class KeywordService {
                          .put(token.getToken(), token.getMemberId());
         }
 
-        titleToTokens.forEach((title, tokenMap) -> 
-            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, notice.getTitle(), FcmMessageType.SCHOOL_NOTICE, notice.getId())
+        titleToTokens.forEach((title, tokenMap) ->
+            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, notice.getTitle(), FcmMessageType.SCHOOL_NOTICE, notice.getId(), notice.getUrl())
         );
     }
 
@@ -150,8 +150,8 @@ public class KeywordService {
         }
 
         final String finalBody = body;
-        titleToTokens.forEach((title, tokenMap) -> 
-            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, finalBody, FcmMessageType.DEPARTMENT, departmentNotice.getId())
+        titleToTokens.forEach((title, tokenMap) ->
+            fcmAsyncService.sendAsyncKeywordNotice(tokenMap, title, finalBody, FcmMessageType.DEPARTMENT, departmentNotice.getId(), departmentNotice.getUrl())
         );
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
@@ -59,7 +59,7 @@ public class FriendService {
                 .build();
         friendRepository.save(friend);
 
-        fcmAsyncService.sendAsyncTrackedNotification(List.of(receiver.getId()), "친구 요청", requester.getNickname() + "님이 친구 요청을 보냈습니다.", FcmMessageType.FRIEND, friend.getId());
+        fcmAsyncService.sendAsyncTrackedNotification(List.of(receiver.getId()), "친구 요청", requester.getNickname() + "님이 친구 요청을 보냈습니다.", FcmMessageType.FRIEND, friend.getId(), "/friend/list");
     }
 
     @Transactional(readOnly = true)
@@ -124,7 +124,7 @@ public class FriendService {
 
         friend.accept();
 
-        fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 수락", friend.getReceiver().getNickname() + "님이 친구 요청을 수락했습니다.", FcmMessageType.FRIEND, friend.getId());
+        fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 수락", friend.getReceiver().getNickname() + "님이 친구 요청을 수락했습니다.", FcmMessageType.FRIEND, friend.getId(), "/friend/list");
     }
 
     @Transactional
@@ -137,7 +137,7 @@ public class FriendService {
         }
 
         if (friend.getStatus() == FriendStatus.PENDING && friend.getReceiver().getId().equals(memberId)) {
-            fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 요청 결과", "친구 요청이 거절되었습니다.", FcmMessageType.FRIEND, friend.getId());
+            fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 요청 결과", "친구 요청이 거절되었습니다.", FcmMessageType.FRIEND, friend.getId(), "/friend/list");
         }
 
         friendRepository.delete(friend);


### PR DESCRIPTION
## 📎 관련 이슈

- closed #271

## 📄 설명

알림 탭 구현을 위해 FCM 페이로드에 라우팅용 `path`를 추가했습니다.

- `notification` + `data`를 항상 함께 발송, `path`는 `data` 블록에만 포함
- `path` 규격: 웹 이동은 URL 원문, 앱 내부 이동은 상대경로
- FCM 발송 체인(`sendAsyncKeywordNotice`, `sendAsyncTrackedNotification` 등)에 `path` 오버로드 추가
- 공지: 공지 웹 URL 전달 / 채팅: `/chat/{roomId}` / 총학공지: `/councilnoticedetail?id={id}` / 친구: `/friend/list`

## 🤔 추후 작업 사항

- 친구 상세 페이지 만들어지면 route 변경