### PR TITLE
✨ fix: 대표 시간표 삭제 시 같은 학기의 남은 시간표가 대표로 승격되지 않는 문제

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/dto/FriendResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/dto/FriendResponseDto.java
@@ -1,22 +1,13 @@
 package kr.inuappcenterportal.inuportal.domain.member.dto;
 
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-public class FriendResponseDto {
-    private Long friendId; // friend 엔티티의 ID
-    private String nickname;
-    private String studentId;
-    private Long fireId;
-    private String friendAlias;
-
+/**
+ * @param friendId friend 엔티티의 ID
+ */
+public record FriendResponseDto(Long friendId, Long friendMemberId, String nickname, String studentId, Long fireId,
+                                String friendAlias) {
     @Builder
-    public FriendResponseDto(Long friendId, String nickname, String studentId, Long fireId, String friendAlias) {
-        this.friendId = friendId;
-        this.nickname = nickname;
-        this.studentId = studentId;
-        this.fireId = fireId;
-        this.friendAlias = friendAlias;
+    public FriendResponseDto {
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
@@ -153,6 +153,7 @@ public class FriendService {
 
         List<FriendResponseDto> list = sent.stream().map(f -> FriendResponseDto.builder()
                 .friendId(f.getId())
+                .friendMemberId(f.getReceiver().getId())
                 .nickname(f.getReceiver().getNickname())
                 .studentId(f.getReceiver().getMaskedStudentId())
                 .fireId(f.getReceiver().getFireId())
@@ -162,6 +163,7 @@ public class FriendService {
 
         list.addAll(received.stream().map(f -> FriendResponseDto.builder()
                 .friendId(f.getId())
+                .friendMemberId(f.getRequester().getId())
                 .nickname(f.getRequester().getNickname())
                 .studentId(f.getRequester().getMaskedStudentId())
                 .fireId(f.getRequester().getFireId())

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
@@ -227,7 +227,7 @@ public class FriendService {
         String friendAlias = friend.getRequester().getId().equals(viewerId) ? friend.getRequesterAlias() : friend.getReceiverAlias();
 
         return MemberProfileResponseDto.builder()
-                .memberId(null)
+                .memberId(target.getId())
                 .nickname(target.getNickname())
                 .fireId(target.getFireId())
                 .department(target.getDepartment())

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableApiSpecification.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableApiSpecification.java
@@ -31,19 +31,13 @@ public interface TimeTableApiSpecification {
 
 
     @Operation(
-            summary = "시간표 상세 조회",
+            summary = "내 시간표 상세 조회",
             description = """
-                    로그인한 사용자가 소유한 시간표 또는 친구의 공개 시간표 상세 정보를 조회합니다.
+                    로그인한 사용자가 소유한 시간표의 상세 정보를 조회합니다.
                     <br><br>
                     시간표 기본 정보와 시간표에 포함된 모든 요소를 함께 반환합니다.
                     <br>
                     각 시간표 요소는 type에 따라 course 또는 customSchedule 중 하나만 값을 가집니다.
-                    <br><br>
-                    본인 시간표는 공개 범위와 관계없이 전체 정보를 반환합니다.
-                    <br>
-                    친구 시간표는 PUBLIC이면 전체 정보를 반환하고, PROTECTED이면 요일/시작 시간/종료 시간만 반환합니다.
-                    <br>
-                    친구가 아니거나 차단 관계이면 조회할 수 없으며, PRIVATE 시간표도 조회할 수 없습니다.
                     """
     )
     @ApiResponses(value = {
@@ -53,9 +47,121 @@ public interface TimeTableApiSpecification {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ResponseDto.class),
+                            examples = @ExampleObject(
+                                    name = "내 시간표 상세 조회 응답 예시",
+                                    value = """
+                                            {
+                                              "data": {
+                                                "id": 1,
+                                                "timeTableName": "1학기 기본 시간표",
+                                                "year": 2026,
+                                                "term": "FIRST",
+                                                "items": [
+                                                  {
+                                                    "id": 10,
+                                                    "type": "COURSE",
+                                                    "memo": "중간고사 중요",
+                                                    "course": {
+                                                      "courseOfferingId": 3,
+                                                      "courseId": 12,
+                                                      "title": "웹프로그래밍",
+                                                      "professor": "박기석",
+                                                      "subjectNumber": "0001421001",
+                                                      "credit": "3",
+                                                      "meetings": [
+                                                        {
+                                                          "id": 21,
+                                                          "location": "07-415",
+                                                          "sequence": 1,
+                                                          "day": "TUESDAY",
+                                                          "startTime": "09:00",
+                                                          "endTime": "10:15"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "customSchedule": null
+                                                  }
+                                                ]
+                                              },
+                                              "msg": "시간표 상세 조회 성공"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "본인 소유 시간표가 아닙니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseDto.class),
+                            examples = @ExampleObject(
+                                    name = "내 시간표 상세 조회 권한 없음",
+                                    value = """
+                                            {
+                                              "data": null,
+                                              "msg": "해당 시간표에 접근할 권한이 없습니다."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 시간표입니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseDto.class),
+                            examples = @ExampleObject(
+                                    name = "시간표 없음",
+                                    value = """
+                                            {
+                                              "data": null,
+                                              "msg": "존재하지 않는 시간표입니다."
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    ResponseEntity<ResponseDto<TimeTableDetailResponseDto>> getTimeTableDetail(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Member member,
+            @Parameter(
+                    name = "timeTableId",
+                    description = "상세 조회할 시간표 id",
+                    in = ParameterIn.PATH,
+                    example = "1"
+            )
+            @PathVariable Long timeTableId
+    );
+
+    @Operation(
+            summary = "친구 대표 시간표 상세 조회",
+            description = """
+                    친구의 특정 년도/학기 대표 시간표 상세 정보를 조회합니다.
+                    <br><br>
+                    친구 관계이고 차단 관계가 아니어야 조회할 수 있습니다.
+                    <br>
+                    대표 시간표는 회원별/학기별로 최대 1개만 존재할 수 있으며, 사용자가 대표 시간표를 삭제한 경우처럼 대표 시간표가 없을 수 있습니다.
+                    <br>
+                    친구의 해당 학기 대표 시간표가 없으면 조회할 수 없습니다.
+                    <br>
+                    PUBLIC이면 전체 정보를 반환하고, PROTECTED이면 요일/시작 시간/종료 시간만 반환합니다.
+                    <br>
+                    PRIVATE 시간표는 조회할 수 없습니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "친구 대표 시간표 상세 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseDto.class),
                             examples = {
                                     @ExampleObject(
-                                            name = "본인 또는 PUBLIC 친구 시간표 상세 조회 응답 예시",
+                                            name = "PUBLIC 친구 대표 시간표 상세 조회 응답 예시",
                                             value = """
                                                     {
                                                       "data": {
@@ -87,35 +193,15 @@ public interface TimeTableApiSpecification {
                                                               ]
                                                             },
                                                             "customSchedule": null
-                                                          },
-                                                          {
-                                                            "id": 11,
-                                                            "type": "CUSTOM",
-                                                            "memo": "개인 일정",
-                                                            "course": null,
-                                                            "customSchedule": {
-                                                              "customScheduleId": 7,
-                                                              "title": "알바",
-                                                              "meetings": [
-                                                                {
-                                                                  "id": 31,
-                                                                  "location": "송도",
-                                                                  "sequence": null,
-                                                                  "day": "MONDAY",
-                                                                  "startTime": "18:00",
-                                                                  "endTime": "21:00"
-                                                                }
-                                                              ]
-                                                            }
                                                           }
                                                         ]
                                                       },
-                                                      "msg": "시간표 상세 조회 성공"
+                                                      "msg": "친구 대표 시간표 상세 조회 성공"
                                                     }
                                                     """
                                     ),
                                     @ExampleObject(
-                                            name = "PROTECTED 친구 시간표 상세 조회 응답 예시",
+                                            name = "PROTECTED 친구 대표 시간표 상세 조회 응답 예시",
                                             value = """
                                                     {
                                                       "data": {
@@ -147,34 +233,31 @@ public interface TimeTableApiSpecification {
                                                               ]
                                                             },
                                                             "customSchedule": null
-                                                          },
-                                                          {
-                                                            "id": null,
-                                                            "type": "CUSTOM",
-                                                            "memo": null,
-                                                            "course": null,
-                                                            "customSchedule": {
-                                                              "customScheduleId": null,
-                                                              "title": null,
-                                                              "meetings": [
-                                                                {
-                                                                  "id": null,
-                                                                  "location": null,
-                                                                  "sequence": null,
-                                                                  "day": "MONDAY",
-                                                                  "startTime": "18:00",
-                                                                  "endTime": "21:00"
-                                                                }
-                                                              ]
-                                                            }
                                                           }
                                                         ]
                                                       },
-                                                      "msg": "시간표 상세 조회 성공"
+                                                      "msg": "친구 대표 시간표 상세 조회 성공"
                                                     }
                                                     """
                                     )
                             }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "year와 term 중 하나만 입력했거나 존재하지 않는 학기입니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseDto.class),
+                            examples = @ExampleObject(
+                                    name = "친구 대표 시간표 상세 조회 요청값 오류",
+                                    value = """
+                                            {
+                                              "data": null,
+                                              "msg": "년도와 학기는 함께 입력해야합니다."
+                                            }
+                                            """
+                            )
                     )
             ),
             @ApiResponse(
@@ -185,7 +268,7 @@ public interface TimeTableApiSpecification {
                             schema = @Schema(implementation = ResponseDto.class),
                             examples = {
                                     @ExampleObject(
-                                            name = "친구 시간표 조회 권한 없음",
+                                            name = "친구 대표 시간표 조회 권한 없음",
                                             value = """
                                                     {
                                                       "data": null,
@@ -194,7 +277,7 @@ public interface TimeTableApiSpecification {
                                                     """
                                     ),
                                     @ExampleObject(
-                                            name = "비공개 시간표 조회 실패",
+                                            name = "비공개 대표 시간표 조회 실패",
                                             value = """
                                                     {
                                                       "data": null,
@@ -207,12 +290,12 @@ public interface TimeTableApiSpecification {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "존재하지 않는 시간표입니다.",
+                    description = "친구의 해당 년도/학기 대표 시간표가 존재하지 않습니다.",
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ResponseDto.class),
                             examples = @ExampleObject(
-                                    name = "시간표 없음",
+                                    name = "친구 대표 시간표 없음",
                                     value = """
                                             {
                                               "data": null,
@@ -223,16 +306,29 @@ public interface TimeTableApiSpecification {
                     )
             )
     })
-    ResponseEntity<ResponseDto<TimeTableDetailResponseDto>> getTimeTableDetail(
+    ResponseEntity<ResponseDto<TimeTableDetailResponseDto>> getFriendPrimarySemesterTimeTable(
             @Parameter(hidden = true)
             @AuthenticationPrincipal Member member,
             @Parameter(
-                    name = "timeTableId",
-                    description = "상세 조회할 시간표 id",
+                    name = "friendMemberId",
+                    description = "대표 시간표를 조회할 친구 회원 id",
                     in = ParameterIn.PATH,
-                    example = "1"
+                    example = "2"
             )
-            @PathVariable Long timeTableId
+            @PathVariable Long friendMemberId,
+            @Parameter(
+                    description = "조회할 학년도. term과 함께 입력해야 합니다.",
+                    example = "2026"
+            )
+            @RequestParam(required = false) Integer year,
+            @Parameter(
+                    description = "조회할 학기. year와 함께 입력해야 합니다.",
+                    schema = @Schema(
+                            allowableValues = {"FIRST", "SUMMER", "SECOND", "WINTER"},
+                            example = "FIRST"
+                    )
+            )
+            @RequestParam(required = false) SemesterTerm term
     );
 
 
@@ -447,7 +543,13 @@ public interface TimeTableApiSpecification {
 
     @Operation(
             summary = "대표 시간표 변경",
-            description = "로그인한 사용자가 소유한 시간표를 해당 학기의 대표 시간표로 설정합니다."
+            description = """
+                    로그인한 사용자가 소유한 시간표를 해당 학기의 대표 시간표로 설정합니다.
+                    <br><br>
+                    대표 시간표는 회원별/학기별로 최대 1개만 존재할 수 있습니다.
+                    <br>
+                    대표 시간표는 반드시 존재해야 하는 값은 아니며, 대표 시간표를 삭제해도 다른 시간표가 자동으로 대표 시간표로 지정되지 않습니다.
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -570,7 +672,13 @@ public interface TimeTableApiSpecification {
 
     @Operation(
             summary = "시간표 삭제",
-            description = "로그인한 사용자가 소유한 시간표를 삭제합니다."
+            description = """
+                    로그인한 사용자가 소유한 시간표를 삭제합니다.
+                    <br><br>
+                    삭제한 시간표가 대표 시간표여도 다른 시간표가 자동으로 대표 시간표로 지정되지 않습니다.
+                    <br>
+                    따라서 해당 회원의 해당 학기에는 대표 시간표가 없을 수 있습니다.
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -623,7 +731,13 @@ public interface TimeTableApiSpecification {
 
     @Operation(
             summary = "시간표 생성",
-            description = "로그인한 사용자의 특정 학기에 시간표를 생성합니다. 해당 학기의 첫 시간표이면 대표 시간표로 생성됩니다."
+            description = """
+                    로그인한 사용자의 특정 학기에 시간표를 생성합니다.
+                    <br><br>
+                    해당 학기의 첫 시간표이면 편의상 대표 시간표로 생성됩니다.
+                    <br>
+                    대표 시간표는 반드시 존재해야 하는 값은 아니며, 사용자가 따로 대표 시간표를 설정하지 않으면 자동으로 다시 설정되지 않습니다.
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableController.java
@@ -27,7 +27,7 @@ public class TimeTableController implements TimeTableApiSpecification {
 
 
     /**
-     * 시간표 상세 조회 컨트롤러
+     * 내 시간표 상세 조회 컨트롤러
      */
     @GetMapping("/{timeTableId}")
     public ResponseEntity<ResponseDto<TimeTableDetailResponseDto>> getTimeTableDetail(
@@ -39,6 +39,24 @@ public class TimeTableController implements TimeTableApiSpecification {
 
         return ResponseEntity.ok(
                 ResponseDto.of(response, "시간표 상세 조회 성공")
+        );
+    }
+
+    /**
+     * 친구 대표 시간표 학기별 조회 컨트롤러
+     */
+    @GetMapping("/friends/{friendMemberId}/primary")
+    public ResponseEntity<ResponseDto<TimeTableDetailResponseDto>> getFriendPrimarySemesterTimeTable(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long friendMemberId,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) SemesterTerm term
+    ) {
+        TimeTableDetailResponseDto response =
+                timeTableService.getFriendPrimaryTimeTableDetailYearAndTerm(member.getId(), friendMemberId, year, term);
+
+        return ResponseEntity.ok(
+                ResponseDto.of(response, "친구 대표 시간표 상세 조회 성공")
         );
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timtable/TimeTableDetailResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timtable/TimeTableDetailResponseDto.java
@@ -1,5 +1,6 @@
 package kr.inuappcenterportal.inuportal.domain.timeTable.dto.response.timtable;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.inuappcenterportal.inuportal.domain.semester.enums.SemesterTerm;
 import kr.inuappcenterportal.inuportal.domain.timeTable.dto.response.timeTableItem.TimeTableDetailItemResponseDto;
 import kr.inuappcenterportal.inuportal.domain.timeTable.model.TimeTable;
@@ -7,10 +8,15 @@ import kr.inuappcenterportal.inuportal.domain.timeTable.model.TimeTable;
 import java.util.List;
 
 public record TimeTableDetailResponseDto(
+        @Schema(description = "시간표 id", example = "1")
         Long id,
+        @Schema(description = "시간표 이름", example = "1학기 기본 시간표")
         String timeTableName,
+        @Schema(description = "학년도", example = "2026")
         Integer year,
+        @Schema(description = "학기", example = "FIRST")
         SemesterTerm term,
+        @Schema(description = "시간표 요소 상세 목록")
         List<TimeTableDetailItemResponseDto> items
 ) {
     public static TimeTableDetailResponseDto from(

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timtable/TimeTableResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timtable/TimeTableResponseDto.java
@@ -1,16 +1,24 @@
 package kr.inuappcenterportal.inuportal.domain.timeTable.dto.response.timtable;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.inuappcenterportal.inuportal.domain.semester.enums.SemesterTerm;
 import kr.inuappcenterportal.inuportal.domain.timeTable.enums.Visibility;
 import kr.inuappcenterportal.inuportal.domain.timeTable.model.TimeTable;
 
 public record TimeTableResponseDto(
+        @Schema(description = "시간표 id", example = "1")
         Long id,
+        @Schema(description = "학기 id", example = "3")
         Long semesterId,
+        @Schema(description = "학년도", example = "2026")
         Integer year,
+        @Schema(description = "학기", example = "FIRST")
         SemesterTerm term,
+        @Schema(description = "시간표 이름", example = "1학기 기본 시간표")
         String timeTableName,
+        @Schema(description = "대표 시간표 여부. 회원별/학기별로 최대 1개만 true가 될 수 있으며, 대표 시간표가 없을 수도 있습니다.", example = "true")
         boolean isPrimary,
+        @Schema(description = "시간표 공개 범위", example = "PUBLIC")
         Visibility visibility
 ) {
     public static TimeTableResponseDto from(TimeTable timeTable) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableService.java
@@ -51,7 +51,7 @@ public class TimeTableService {
 
 
     /**
-     * 시간표 상세 조회 메서드
+     * 내 시간표 상세 조회 메서드
      */
     public TimeTableDetailResponseDto getTimeTableDetail(
             Long memberId,
@@ -60,20 +60,12 @@ public class TimeTableService {
         TimeTable timeTable = timeTableRepository.findById(timeTableId)
                 .orElseThrow(() -> new MyException(MyErrorCode.TIMETABLE_NOT_FOUND));
 
-        boolean owner = timeTable.getMember().getId().equals(memberId);
-        List<TimeTableDetailItemResponseDto> items;
+        validateOwner(timeTable, memberId);
 
-        if (owner) {
-            items = timeTableItemRepository.findAllByTimeTableId(timeTableId).stream()
-                    .map(this::toDetailItemResponse)
-                    .toList();
-        } else {
-            Visibility visibility = validateFriendTimeTableReadable(timeTable, memberId);
+        List<TimeTableDetailItemResponseDto> items = timeTableItemRepository.findAllByTimeTableId(timeTableId).stream()
+                .map(this::toDetailItemResponse)
+                .toList();
 
-            items = timeTableItemRepository.findAllByTimeTableId(timeTableId).stream()
-                    .map(item -> toDetailItemResponse(item, visibility))
-                    .toList();
-        }
         return TimeTableDetailResponseDto.from(timeTable, items);
     }
 
@@ -104,40 +96,6 @@ public class TimeTableService {
                 yield TimeTableDetailItemResponseDto.ofCustom(
                         item,
                         CustomTimeTableItemResponseDto.of(customSchedule, meetings)
-                );
-            }
-        };
-    }
-
-    // 친구용
-    private TimeTableDetailItemResponseDto toDetailItemResponse(
-            TimeTableItem item,
-            Visibility visibility
-    ) {
-        return switch (item.getType()) {
-            case COURSE -> {
-                CourseOffering courseOffering = item.getCourseOffering();
-
-                List<CourseMeeting> meetings =
-                        courseMeetingRepository.findAllByCourseOfferingId(courseOffering.getId());
-
-                yield TimeTableDetailItemResponseDto.ofCourse(
-                        item,
-                        CourseTimeTableItemResponseDto.of(courseOffering, meetings, visibility),
-                        visibility
-                );
-            }
-
-            case CUSTOM -> {
-                CustomSchedule customSchedule = item.getCustomSchedule();
-
-                List<CustomScheduleMeeting> meetings =
-                        customScheduleMeetingRepository.findAllByCustomScheduleId(customSchedule.getId());
-
-                yield TimeTableDetailItemResponseDto.ofCustom(
-                        item,
-                        CustomTimeTableItemResponseDto.of(customSchedule, meetings, visibility),
-                        visibility
                 );
             }
         };
@@ -307,16 +265,7 @@ public class TimeTableService {
     /**
      * 친구의 시간표를 읽을 수 있는지 검증하는 메서드
      */
-    private Visibility validateFriendTimeTableReadable(TimeTable timeTable, Long memberId) {
-        // memberId는 로그인한 사용자, timeTable로 얻는 Id는 그 시간표의 소유자 ID(즉, 친구 ID)
-        boolean friend = friendService.isReadableFriend(memberId, timeTable.getMember().getId());
-
-        // 친구관계가 아니면 시간표 조회 불가능
-        if (!friend) {
-            throw new MyException(MyErrorCode.NOT_READABLE_TIMETABLE);
-        }
-
-        // 해당 시간표의 공개범위를 확인
+    private Visibility validateFriendTimeTableVisibility(TimeTable timeTable) {
         return switch (timeTable.getVisibility()) {
             case PRIVATE -> throw new MyException(MyErrorCode.PRIVATE_TIMETABLE);
             case PROTECTED -> Visibility.PROTECTED;
@@ -361,5 +310,81 @@ public class TimeTableService {
         return timeTableRepository.findAllByMemberIdAndSemesterId(memberId, semesterId).stream()
                 .map(TimeTableResponseDto::from)
                 .toList();
+    }
+
+
+    /**
+     * 학기별 친구 대표 시간표 상세 조회 (년도+학기)
+     */
+    public TimeTableDetailResponseDto getFriendPrimaryTimeTableDetailYearAndTerm(
+            Long viewerId,
+            Long friendMemberId,
+            Integer year,
+            SemesterTerm term
+    ) {
+        // 입력 검증
+        if (year == null || term == null) {
+            throw new MyException(MyErrorCode.INPUT_YEAR_AND_TERM);
+        }
+
+        // 학기 가져오기
+        Long semesterId = semesterRepository.findByYearAndTerm(year, term)
+                .orElseThrow(() -> new MyException(MyErrorCode.SEMESTER_NOT_FOUND))
+                .getId();
+
+        // 친구관계인지 검증
+        if (!friendService.isReadableFriend(viewerId, friendMemberId)) {
+            throw new MyException(MyErrorCode.NOT_READABLE_TIMETABLE);
+        }
+
+        // 친구의 시간표 가져오기
+        TimeTable timeTable = timeTableRepository
+                .findByMemberIdAndSemesterIdAndIsPrimaryTrue(friendMemberId, semesterId)
+                .orElseThrow(() -> new MyException(MyErrorCode.PRIMARY_TIMETABLE_NOT_FOUND));
+
+        // 친구 시간표의 공개범위 확인
+        Visibility visibility = validateFriendTimeTableVisibility(timeTable);
+
+        // 공개범위에 따라 가져올 item 선택
+        List<TimeTableDetailItemResponseDto> items =
+                timeTableItemRepository.findAllByTimeTableId(timeTable.getId()).stream()
+                        .map(item -> toDetailItemResponse(item, visibility))
+                        .toList();
+
+        return TimeTableDetailResponseDto.from(timeTable, items);
+    }
+
+    // 친구용
+    private TimeTableDetailItemResponseDto toDetailItemResponse(
+            TimeTableItem item,
+            Visibility visibility
+    ) {
+        return switch (item.getType()) {
+            case COURSE -> {
+                CourseOffering courseOffering = item.getCourseOffering();
+
+                List<CourseMeeting> meetings =
+                        courseMeetingRepository.findAllByCourseOfferingId(courseOffering.getId());
+
+                yield TimeTableDetailItemResponseDto.ofCourse(
+                        item,
+                        CourseTimeTableItemResponseDto.of(courseOffering, meetings, visibility),
+                        visibility
+                );
+            }
+
+            case CUSTOM -> {
+                CustomSchedule customSchedule = item.getCustomSchedule();
+
+                List<CustomScheduleMeeting> meetings =
+                        customScheduleMeetingRepository.findAllByCustomScheduleId(customSchedule.getId());
+
+                yield TimeTableDetailItemResponseDto.ofCustom(
+                        item,
+                        CustomTimeTableItemResponseDto.of(customSchedule, meetings, visibility),
+                        visibility
+                );
+            }
+        };
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
@@ -97,6 +97,7 @@ public enum MyErrorCode {
     TIMETABLE_ITEM_TIME_CONFLICT(HttpStatus.CONFLICT, "시간표 요소의 시간이 중복입니다."),
     PRIVATE_TIMETABLE(HttpStatus.FORBIDDEN, "비공개된 시간표입니다."),
     NOT_READABLE_TIMETABLE(HttpStatus.FORBIDDEN, "친구가 아닌 사용자의 시간표를 읽을 수 없습니다."),
+    PRIMARY_TIMETABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 시간표가 존재하지 않습니다."),
 
 
     // Chat 관련 에러 코드 추가


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- 첫 시간표 생성시 대표 시간표로 설정하는 것은 단순 편의, 대표 없음으로 정책 확정
- 추가로 시간표 상세 조회 api에서 친구와 내 시간표 조회 로직이 섞여있던걸 분리 및 친구 시간표 조회 시에는 해당 학기의 대표 시간표만 조회 할 수 있도록 별도의 친구 시간표 상세 조회 메서드 개발

## 🤔 추후 작업 사항

- 대표 시간표를 0~1개를 유지하기 위해 DB제약이 필요