### PR TITLE
✨ fix: open학기가 여러 개일때 어떤 걸 선택할지에 대한 정책 문제 및 종료일 계산 로직 삭제

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/model/Semester.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/model/Semester.java
@@ -73,4 +73,14 @@ public class Semester extends BaseTimeEntity {
     public void updateStatus(SemesterStatus status) {
         this.status = status;
     }
+
+    public void updatePeriodAndStatus(
+            LocalDate startDate,
+            LocalDate endDate,
+            SemesterStatus status
+    ) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/repository/SemesterRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/repository/SemesterRepository.java
@@ -13,6 +13,6 @@ public interface SemesterRepository extends JpaRepository<Semester, Long> {
     // 년도와 term으로 학기 찾기
     Optional<Semester> findByYearAndTerm(Integer year, SemesterTerm term);
 
-    // status가 주어진 목록 안에 포함되는 Semester를 찾고 year 내림차순, term 오름차순으로 정렬
-    List<Semester> findAllByStatusInOrderByYearDescTermAsc(List<SemesterStatus> statuses);
+    // status가 주어진 목록 안에 포함되는 Semester 조회
+    List<Semester> findAllByStatusIn(List<SemesterStatus> statuses);
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/scheduler/SemesterScheduler.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/scheduler/SemesterScheduler.java
@@ -40,9 +40,9 @@ public class SemesterScheduler {
     }
 
     /**
-     * 매월 1일 새벽 5시에 학기 자동 동기화
+     * 매월 3일 새벽 5시에 학기 자동 동기화
      */
-    @Scheduled(cron = "0 0 5 1 * *")
+    @Scheduled(cron = "0 0 5 3 * *")
     @SchedulerLock(
             name = "semester-sync",
             lockAtMostFor = "PT10M",

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/service/SemesterService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/service/SemesterService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,12 +32,35 @@ public class SemesterService {
      */
     @Transactional(readOnly = true)
     public List<SemesterResponseDto> getSemesters() {
-        return semesterRepository.findAllByStatusInOrderByYearDescTermAsc(
-                        List.of(SemesterStatus.OPEN, SemesterStatus.CLOSED, SemesterStatus.UPCOMING)
+        return semesterRepository.findAllByStatusIn(
+                        List.of(SemesterStatus.OPEN, SemesterStatus.CLOSED)
                 )
                 .stream()
+                .sorted(Comparator
+                        .comparingInt((Semester semester) -> statusOrder(semester.getStatus()))
+                        .thenComparing(Semester::getYear, Comparator.reverseOrder())
+                        .thenComparingInt(semester -> termOrderDescending(semester.getTerm())))
                 .map(SemesterResponseDto::from)
                 .toList();
+    }
+
+    // 상태 기준 정렬
+    private int statusOrder(SemesterStatus status) {
+        return switch (status) {
+            case OPEN -> 0;
+            case CLOSED -> 1;
+            case UPCOMING -> 2;
+        };
+    }
+
+    // 학기 기준 정렬
+    private int termOrderDescending(SemesterTerm term) {
+        return switch (term) {
+            case WINTER -> 1;
+            case SECOND -> 2;
+            case SUMMER -> 3;
+            case FIRST -> 4;
+        };
     }
 
     /**

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/service/SemesterService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/semester/service/SemesterService.java
@@ -93,25 +93,19 @@ public class SemesterService {
     private void createSemester(
             Integer year,
             SemesterTerm term,
-            Optional<Schedule> startSchedule,
+            Optional<Schedule> semesterSchedule,
             Optional<Schedule> summerSemesterStart,
             Optional<Schedule> winterSemesterStart
     ) {
-        if (startSchedule.isEmpty()) {
+        if (semesterSchedule.isEmpty()) {
             return;
         }
 
-        boolean alreadyExists = semesterRepository.findByYearAndTerm(year, term).isPresent();
-
-        if (alreadyExists) {
-            return;
-        }
-
-        LocalDate startDate = startSchedule.get().getStartDate(); // 학기 시작일
+        LocalDate startDate = semesterSchedule.get().getStartDate(); // 학기 시작일
 
         LocalDate endDate = calculateEndDate( // 학기 종료일
                 term,
-                startDate,
+                semesterSchedule,
                 summerSemesterStart,
                 winterSemesterStart
         );
@@ -120,18 +114,19 @@ public class SemesterService {
             return;
         }
 
-        SemesterStatus status = calculateStatus(startDate, endDate, LocalDate.now(clock)); // 학기 상태 계산
+        // 학기 상태 계산
+        SemesterStatus status = calculateStatus(startDate, endDate, LocalDate.now(clock));
 
 
-        Semester semester = Semester.create(
-                year,
-                term,
-                status,
-                startDate,
-                endDate
-        );
-
-        semesterRepository.save(semester);
+        // 정규학기 종료일은 계절학기 시작일 기준으로 계산
+        // 계절학기 종료일은 학사일정의 endDate 그대로 사용
+        semesterRepository.findByYearAndTerm(year, term)
+                .ifPresentOrElse(
+                        semester -> semester.updatePeriodAndStatus(startDate, endDate, status),
+                        () -> semesterRepository.save(
+                                Semester.create(year, term, status, startDate, endDate)
+                        )
+                );
     }
 
     /**
@@ -139,7 +134,7 @@ public class SemesterService {
      */
     private LocalDate calculateEndDate(
             SemesterTerm term,
-            LocalDate startDate,
+            Optional<Schedule> semesterSchedule,
             Optional<Schedule> summerSemesterStart,
             Optional<Schedule> winterSemesterStart
     ) {
@@ -157,9 +152,11 @@ public class SemesterService {
                     .orElse(null);
         }
 
-        // 각 계절학기는 정확히 3주, 21일간 진행
+        // 계절학기는 학사일정에 저장된 종료일을 그대로 사용
         if (term == SemesterTerm.SUMMER || term == SemesterTerm.WINTER) {
-            return startDate.plusDays(20);
+            return semesterSchedule
+                    .map(Schedule::getEndDate)
+                    .orElse(null);
         }
 
         return null;

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
@@ -258,7 +258,7 @@ public class TimeTableItemService {
             );
 
             if (exists) {
-                throw new MyException(MyErrorCode.TIMETABLE_ITEM_TIME_CONFLICT);
+                throw new MyException(MyErrorCode.TIMETABLE_ITEM_TIME_DB_CONFLICT);
             }
         }
     }
@@ -278,7 +278,7 @@ public class TimeTableItemService {
                 if (current.day() == other.day()
                         && current.startTime().isBefore(other.endTime())
                         && current.endTime().isAfter(other.startTime())) {
-                    throw new MyException(MyErrorCode.TIMETABLE_ITEM_TIME_CONFLICT);
+                    throw new MyException(MyErrorCode.TIMETABLE_ITEM_TIME_REQUEST_CONFLICT);
                 }
             }
         }

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
@@ -95,6 +95,8 @@ public enum MyErrorCode {
     FASTER_THAN_ENDTIME(HttpStatus.BAD_REQUEST, "시작시간은 종료시간보다 빨라야합니다."),
     NECESSARY_CUSTOM_TITLE(HttpStatus.BAD_REQUEST, "커스텀 일정 제목은 필수입니다."),
     TIMETABLE_ITEM_TIME_CONFLICT(HttpStatus.CONFLICT, "시간표 요소의 시간이 중복입니다."),
+    TIMETABLE_ITEM_TIME_REQUEST_CONFLICT(HttpStatus.CONFLICT, "동일한 시간의 시간표 요소를 추가할 수 없습니다."),
+    TIMETABLE_ITEM_TIME_DB_CONFLICT(HttpStatus.CONFLICT, "동일한 시간의 시간표 요소가 존재합니다."),
     PRIVATE_TIMETABLE(HttpStatus.FORBIDDEN, "비공개된 시간표입니다."),
     NOT_READABLE_TIMETABLE(HttpStatus.FORBIDDEN, "친구가 아닌 사용자의 시간표를 읽을 수 없습니다."),
     PRIMARY_TIMETABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 시간표가 존재하지 않습니다."),

--- a/src/test/java/kr/inuappcenterportal/inuportal/semester/SemesterServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/semester/SemesterServiceTest.java
@@ -2,6 +2,7 @@ package kr.inuappcenterportal.inuportal.semester;
 
 import kr.inuappcenterportal.inuportal.domain.schedule.model.Schedule;
 import kr.inuappcenterportal.inuportal.domain.schedule.repository.ScheduleRepository;
+import kr.inuappcenterportal.inuportal.domain.semester.dto.SemesterResponseDto;
 import kr.inuappcenterportal.inuportal.domain.semester.enums.SemesterStatus;
 import kr.inuappcenterportal.inuportal.domain.semester.enums.SemesterTerm;
 import kr.inuappcenterportal.inuportal.domain.semester.model.Semester;
@@ -61,15 +62,21 @@ public class SemesterServiceTest {
     }
 
     // 테스트용 학기 생성 메서드
-    private Schedule SemesterCreate(int month, int day, String content) {
-        LocalDate date = LocalDate.of(TEST_YEAR, month, day);
-
+    private Schedule createSchedule(LocalDate startDate, LocalDate endDate, String content) {
         return Schedule.builder()
-                .startDate(date)
-                .endDate(date)
+                .startDate(startDate)
+                .endDate(endDate)
                 .content(content)
                 .aiGenerated(false)
                 .build();
+    }
+
+    private Schedule createSchedule(int startMonth, int startDay, int endMonth, int endDay, String content) {
+        return createSchedule(
+                LocalDate.of(TEST_YEAR, startMonth, startDay),
+                LocalDate.of(TEST_YEAR, endMonth, endDay),
+                content
+        );
     }
 
     @Test
@@ -79,10 +86,14 @@ public class SemesterServiceTest {
         // Given
         // 학사일정 크롤링한 데이터로 가정
         List<Schedule> schedules = List.of(
-                SemesterCreate(3, 2, "1학기 개강"),
-                SemesterCreate(6, 22, "하계 계절학기"),
-                SemesterCreate(9, 1, "2학기 개강"),
-                SemesterCreate(12, 22, "동계 계절학기")
+                createSchedule(3, 2, 3, 2, "1학기 개강"),
+                createSchedule(6, 22, 7, 12, "하계 계절학기"),
+                createSchedule(9, 1, 9, 1, "2학기 개강"),
+                createSchedule(
+                        LocalDate.of(TEST_YEAR, 12, 22),
+                        LocalDate.of(TEST_YEAR + 1, 1, 13),
+                        "동계 계절학기"
+                )
         );
 
         // 레포지토리의 동작을 가짜로 지정
@@ -130,18 +141,30 @@ public class SemesterServiceTest {
 
         assertThat(savedSemesters.get(1).getEndDate())
                 .isEqualTo(LocalDate.of(TEST_YEAR, 12, 21));
+
+        assertThat(savedSemesters.get(2).getStartDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR, 6, 22));
+
+        assertThat(savedSemesters.get(2).getEndDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR, 7, 12));
+
+        assertThat(savedSemesters.get(3).getStartDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR, 12, 22));
+
+        assertThat(savedSemesters.get(3).getEndDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR + 1, 1, 13));
     }
 
 
     @Test
-    @DisplayName("이미 같은 연도와 학기의 학기가 있으면 해당 학기는 저장하지 않는다.")
+    @DisplayName("이미 같은 연도와 학기의 학기가 있으면 기간과 상태를 갱신한다.")
     void 중복_학기_검사_로직_테스트() {
 
         // Given
         // 크롤링된 학사일정에 1학기, 하계 계절학가 있다고 가정
         List<Schedule> schedules = List.of(
-                SemesterCreate(3, 2, "1학기 개강"),
-                SemesterCreate(6, 22, "하계 계절학기")
+                createSchedule(3, 2, 3, 2, "1학기 개강"),
+                createSchedule(6, 22, 7, 12, "하계 계절학기")
         );
 
         // 이미 DB에 1학기가 저장되어 있음을 가정
@@ -149,8 +172,8 @@ public class SemesterServiceTest {
                 TEST_YEAR,
                 SemesterTerm.FIRST,
                 SemesterStatus.UPCOMING,
-                LocalDate.of(TEST_YEAR, 3, 2),
-                LocalDate.of(TEST_YEAR, 6, 21)
+                LocalDate.of(TEST_YEAR, 3, 1),
+                LocalDate.of(TEST_YEAR, 6, 20)
         );
 
         // 학사일정을 조회하면 위에서 만든 schedules을 반환
@@ -164,23 +187,33 @@ public class SemesterServiceTest {
         // FIRST를 조회하는 요청이오면 위에서 existingSemester를 반환
         when(semesterRepository.findByYearAndTerm(TEST_YEAR, SemesterTerm.FIRST))
                 .thenReturn(Optional.of(existingSemester));
+        when(semesterRepository.findByYearAndTerm(TEST_YEAR, SemesterTerm.SUMMER))
+                .thenReturn(Optional.empty());
 
         // When
         semesterService.syncSemestersByYear();
 
         // Then
-        // Semester 타입 객체를 잡아둘 캡처 도구를 만든다.
         ArgumentCaptor<Semester> semesterCaptor = ArgumentCaptor.forClass(Semester.class);
-
-        // semesterRepository.save(...)가 1회 호출됐는지 확인하고, 그때 save() 안으로 들어간 Semester 객체를 semesterCaptor가 잡는다.
         verify(semesterRepository, times(1)).save(semesterCaptor.capture());
 
-        // 방금 잡은 Semester 객체를 꺼내서 savedSemester라는 변수에 담는다.
         Semester savedSemester = semesterCaptor.getValue();
 
-        // 저장된 학기의 term이 SUMMER인지 확인한다.
+        assertThat(existingSemester.getStartDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR, 3, 2));
+        assertThat(existingSemester.getEndDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR, 6, 21));
+        assertThat(existingSemester.getStatus())
+                .isEqualTo(SemesterStatus.CLOSED);
+
         assertThat(savedSemester.getTerm())
                 .isEqualTo(SemesterTerm.SUMMER);
+        assertThat(savedSemester.getStartDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR, 6, 22));
+        assertThat(savedSemester.getEndDate())
+                .isEqualTo(LocalDate.of(TEST_YEAR, 7, 12));
+        assertThat(savedSemester.getStatus())
+                .isEqualTo(SemesterStatus.OPEN);
     }
 
 
@@ -190,7 +223,7 @@ public class SemesterServiceTest {
 
         // Given
         List<Schedule> schedules = List.of(
-                SemesterCreate(3, 2, "1학기 개강")
+                createSchedule(3, 2, 3, 2, "1학기 개강")
         );
 
         when(scheduleRepository.findAcademicSemesterSchedules(
@@ -200,15 +233,76 @@ public class SemesterServiceTest {
                 eq("계절학기")
         )).thenReturn(schedules);
 
-        when(semesterRepository.findByYearAndTerm(any(Integer.class), any(SemesterTerm.class)))
-                .thenReturn(Optional.empty());
-
         // When
         semesterService.syncSemestersByYear();
 
         // Then
         // 1학기의 종료일은 하계 계절학기의 -1일인데 하계 계절학기가 주어지지 않아서 생성되지 못하는 걸 체크
         verify(semesterRepository, never()).save(any(Semester.class));
+    }
+
+    @Test
+    @DisplayName("학기 목록은 OPEN과 CLOSED만 최신 학기순으로 조회한다.")
+    void 학기_목록_조회_정렬_테스트() {
+        // Given
+        Semester openFirst = createSemester(
+                2026,
+                SemesterTerm.FIRST,
+                SemesterStatus.OPEN,
+                LocalDate.of(2026, 3, 2),
+                LocalDate.of(2026, 6, 21)
+        );
+
+        Semester openSummer = createSemester(
+                2026,
+                SemesterTerm.SUMMER,
+                SemesterStatus.OPEN,
+                LocalDate.of(2026, 6, 22),
+                LocalDate.of(2026, 7, 12)
+        );
+
+        Semester closedSecond = createSemester(
+                2025,
+                SemesterTerm.SECOND,
+                SemesterStatus.CLOSED,
+                LocalDate.of(2025, 9, 1),
+                LocalDate.of(2025, 12, 21)
+        );
+
+        Semester closedWinter = createSemester(
+                2025,
+                SemesterTerm.WINTER,
+                SemesterStatus.CLOSED,
+                LocalDate.of(2025, 12, 22),
+                LocalDate.of(2026, 1, 13)
+        );
+
+        when(semesterRepository.findAllByStatusIn(List.of(SemesterStatus.OPEN, SemesterStatus.CLOSED)))
+                .thenReturn(List.of(closedSecond, openFirst, closedWinter, openSummer));
+
+        // When
+        List<SemesterResponseDto> response = semesterService.getSemesters();
+
+        // Then
+        assertThat(response)
+                .extracting(SemesterResponseDto::term)
+                .containsExactly(
+                        SemesterTerm.SUMMER,
+                        SemesterTerm.FIRST,
+                        SemesterTerm.WINTER,
+                        SemesterTerm.SECOND
+                );
+
+        assertThat(response)
+                .extracting(SemesterResponseDto::status)
+                .containsExactly(
+                        SemesterStatus.OPEN,
+                        SemesterStatus.OPEN,
+                        SemesterStatus.CLOSED,
+                        SemesterStatus.CLOSED
+                );
+
+        verify(semesterRepository).findAllByStatusIn(List.of(SemesterStatus.OPEN, SemesterStatus.CLOSED));
     }
 
 
@@ -266,5 +360,21 @@ public class SemesterServiceTest {
 
         assertThat(closedSemester.getStatus())
                 .isEqualTo(SemesterStatus.CLOSED);
+    }
+
+    private Semester createSemester(
+            Integer year,
+            SemesterTerm term,
+            SemesterStatus status,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        return Semester.create(
+                year,
+                term,
+                status,
+                startDate,
+                endDate
+        );
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- 학사일정 데이터에서 개강일은 startDate==endDate, 계절학기는 startDate, endDate가 정상적으로 저장됨. 따라서 학기 종료일 계산하는 로직은 그대로 놔두고, 계절학기는 데이터에서 endDate를 뽑아서 사용할 수 있도록 수정.
- 시간표를 정책에 맞게 정렬해서 응답으로 내려주도록 수정

## 🤔 추후 작업 사항

- ex) 성능 개선 필요