### PR TITLE
✨ fix: 커스텀 일정 시간표 요소 생성이 500으로 실패하고 401로 응답됨

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/repository/TimeTableItemRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/repository/TimeTableItemRepository.java
@@ -47,4 +47,34 @@ public interface TimeTableItemRepository extends JpaRepository<TimeTableItem, Lo
             @Param("excludeTimeTableItemId") Long excludeTimeTableItemId
     );
 
+    @Query("""
+            select case when count(item) > 0 then true else false end
+            from TimeTableItem item
+            where item.timeTable.id = :timeTableId
+              and (
+                exists (
+                  select 1
+                  from CourseMeeting meeting
+                  where meeting.courseOffering = item.courseOffering
+                    and meeting.day = :day
+                    and meeting.startTime < :endTime
+                    and meeting.endTime > :startTime
+                )
+                or exists (
+                  select 1
+                  from CustomScheduleMeeting meeting
+                  where meeting.customSchedule = item.customSchedule
+                    and meeting.day = :day
+                    and meeting.startTime < :endTime
+                    and meeting.endTime > :startTime
+                )
+              )
+            """)
+    boolean existsOverlappingMeeting(
+            @Param("timeTableId") Long timeTableId,
+            @Param("day") DayOfWeek day,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime
+    );
+
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
@@ -86,7 +86,7 @@ public class TimeTableItemService {
 
         // 중복 일정 검증
         validateNoRequestTimeConflict(timeSlots);
-        validateNoDBTimeConflict(timeTableId, timeSlots, null);
+        validateNoDBTimeConflict(timeTableId, timeSlots);
 
         // 커스텀일정 생성
         CustomSchedule customSchedule = customScheduleService.createCustomSchedule(request.title(), meetings);
@@ -240,7 +240,7 @@ public class TimeTableItemService {
     }
 
     /**
-     * 시간표 요소 시간 및 요일 중복 차단 메서드(DB)
+     * 시간표 요소 시간 및 요일 중복 차단 메서드(DB, 수정용)
      */
     private void validateNoDBTimeConflict(
             Long timeTableId,
@@ -255,6 +255,28 @@ public class TimeTableItemService {
                     meeting.startTime(),
                     meeting.endTime(),
                     excludeTimeTableItemId
+            );
+
+            if (exists) {
+                throw new MyException(MyErrorCode.TIMETABLE_ITEM_TIME_DB_CONFLICT);
+            }
+        }
+    }
+
+    /**
+     * 시간표 요소 시간 및 요일 중복 차단 메서드(DB, 생성용)
+     */
+    private void validateNoDBTimeConflict(
+            Long timeTableId,
+            List<TimeSlot> meetings
+    ) {
+        for (TimeSlot meeting : meetings) {
+
+            boolean exists = timeTableItemRepository.existsOverlappingMeeting(
+                    timeTableId,
+                    meeting.day(),
+                    meeting.startTime(),
+                    meeting.endTime()
             );
 
             if (exists) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 최우선 허용 설정
                         .requestMatchers(HttpMethod.GET, "/api/chat-rooms/*/messages/public").permitAll()
-                        .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**", "/images/**", "/actuator/**", "/ws-chat/**", "/api/search", "/api/notices", "/api/notices/**", "/api/schedules", "/api/schedules/**").permitAll()
+                        .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**", "/images/**", "/actuator/**", "/ws-chat/**", "/api/search", "/api/notices", "/api/notices/**", "/api/schedules", "/api/schedules/**", "/error").permitAll()
 
                         // 공통 GET 허용 설정
                         .requestMatchers(HttpMethod.GET, "/api/posts/**", "/api/posts", "/api/cafeterias", "/api/weathers", "/api/councilNotices", "/api/councilNotices/**", "/api/petitions", "/api/petitions/**", "/api/reservations/quantity/**", "/api/directory", "/api/directory/**", "/api/categories/**", "/api/images/**", "/api/books/**", "/api/items/**", "/api/lost/**", "/api/clubs", "/api/clubs/**", "/api/feature-flags", "/api/courses", "/api/semesters").permitAll()


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- 커스텀 일정 생성 시 validateNoDBTimeConflict에서 파라미터에 null이 들어가는 경우 JPQL에서 타입 추론에 실패해 에러가 나는 상황을 해결하기 위해 쿼리를 분리하는 방향으로 수정
- /error 경로를 permitAll 경로에 추가

## 🤔 추후 작업 사항

- ex) 성능 개선 필요