### PR TITLE
✨ refactor: 개설 강의 api 연동 자잘한 버그 수정

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/controller/CourseOfferingApiSpecification.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/controller/CourseOfferingApiSpecification.java
@@ -31,6 +31,7 @@ public interface CourseOfferingApiSpecification {
                     
                     CourseOffering은 YEAR + TERM_CODE + HAKSU_CODE 기준으로 식별합니다.
                     CourseMeeting은 기존 시간을 삭제한 뒤 최신 API 응답 기준으로 다시 저장합니다.
+                    강의 시간 API에만 존재하고 매칭되는 CourseOffering이 없는 시간 정보는 로그를 남기고 스킵합니다.
                     """
     )
     @ApiResponses(value = {
@@ -89,6 +90,8 @@ public interface CourseOfferingApiSpecification {
                     년도와 학기 기준으로 개설 강의 목록을 페이지네이션하여 조회합니다.
                     
                     응답에는 CourseOffering 정보와 해당 개설 강의의 CourseMeeting 목록이 포함됩니다.
+                    CourseOffering의 id는 시간표 요소 생성 시 courseOfferingId로 사용합니다.
+                    온라인 강의 또는 시간 미정 강의는 CourseMeeting 목록이 빈 배열일 수 있습니다.
                     page는 0부터 시작하며, 기본 size는 50입니다.
                     """
     )
@@ -106,6 +109,7 @@ public interface CourseOfferingApiSpecification {
                                               "data": {
                                                 "content": [
                                                   {
+                                                    "id": 10,
                                                     "syllabus": null,
                                                     "subjectNumber": "2000259001",
                                                     "method": "OFFLINE",

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
@@ -11,6 +11,7 @@ import kr.inuappcenterportal.inuportal.domain.semester.enums.SemesterTerm;
 import java.util.List;
 
 public record CourseOfferingResponseDto(
+        Long id,
         String syllabus,
         String subjectNumber,
         Method method,
@@ -30,6 +31,7 @@ public record CourseOfferingResponseDto(
 
     public static CourseOfferingResponseDto from(CourseOffering courseOffering, List<CourseMeeting> meetings) {
         return new CourseOfferingResponseDto(
+                courseOffering.getId(),
                 courseOffering.getSyllabus(),
                 courseOffering.getSubjectNumber(),
                 courseOffering.getMethod(),

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/repository/CourseMeetingRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/repository/CourseMeetingRepository.java
@@ -6,7 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CourseMeetingRepository extends JpaRepository<CourseMeeting, Long> {
+
     List<CourseMeeting> findAllByCourseOfferingId(Long courseOfferingId);
-    
+
     void deleteAllByCourseOfferingId(Long courseOfferingId);
+
+    List<CourseMeeting> findAllByCourseOfferingIdIn(List<Long> courseOfferingIds);
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/repository/CourseOfferingRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/repository/CourseOfferingRepository.java
@@ -3,6 +3,7 @@ package kr.inuappcenterportal.inuportal.domain.course.repository;
 import kr.inuappcenterportal.inuportal.domain.course.model.CourseOffering;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -11,5 +12,6 @@ public interface CourseOfferingRepository extends JpaRepository<CourseOffering, 
 
     Optional<CourseOffering> findBySemesterIdAndSubjectNumber(Long semesterId, String subjectNumber);
 
+    @EntityGraph(attributePaths = {"course", "semester"})
     Page<CourseOffering> findAllBySemesterId(Long semesterId, Pageable pageable);
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseMeetingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseMeetingService.java
@@ -50,7 +50,13 @@ public class CourseMeetingService {
             // 찾은 학기와 학수코드로 개설 강의 찾기
             CourseOffering courseOffering = courseOfferingRepository
                     .findBySemesterIdAndSubjectNumber(semester.getId(), key.haksuCode())
-                    .orElseThrow(() -> new MyException(MyErrorCode.COURSE_OFFERING_NOT_FOUND));
+                    .orElse(null);
+
+            if (courseOffering == null) {
+                log.warn("강의 시간 정보에 해당하는 개설 강의를 찾을 수 없습니다. year={}, termCode={}, haksuCode={}",
+                        key.year(), key.termCode(), key.haksuCode());
+                continue;
+            }
 
             // 업데이트가 될 떄 기존 시간 정보를 지웠다가 다시 생성(이게 더 안전하고 효율적, 데이터가 적어서)
             courseMeetingRepository.deleteAllByCourseOfferingId(courseOffering.getId());

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseMeetingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseMeetingService.java
@@ -35,44 +35,52 @@ public class CourseMeetingService {
      */
     @Transactional
     public void upsertCourseMeetings(
-            Map<CourseMeetingGroupKey, List<CourseMeetingApiItem>> groupedByCourseOffering) {
+            Map<CourseMeetingGroupKey, List<CourseMeetingApiItem>> groupedByCourseOffering
+    ) {
         // API 응답을 CourseOffering별로 묶어서, 해당 개설강의의 시간표 정보를 DB에 새로 저장하는 로직
         for (Map.Entry<CourseMeetingGroupKey, List<CourseMeetingApiItem>> entry : groupedByCourseOffering.entrySet()) {
-            CourseMeetingGroupKey key = entry.getKey();
-            List<CourseMeetingApiItem> meetingItems = entry.getValue();
+            try {
+                CourseMeetingGroupKey key = entry.getKey();
+                List<CourseMeetingApiItem> meetingItems = entry.getValue();
 
-            // API의 YEAR, TERM_CODE로 내부 DB의 Semester 찾기
-            Semester semester = semesterRepository.findByYearAndTerm(
-                    Integer.parseInt(key.year()),
-                    SemesterTerm.mapToTermCode(key.termCode())
-            ).orElseThrow(() -> new MyException(MyErrorCode.SEMESTER_NOT_FOUND));
+                // API의 YEAR, TERM_CODE로 내부 DB의 Semester 찾기
+                Semester semester = semesterRepository.findByYearAndTerm(
+                        Integer.parseInt(key.year()),
+                        SemesterTerm.mapToTermCode(key.termCode())
+                ).orElseThrow(() -> new MyException(MyErrorCode.SEMESTER_NOT_FOUND));
 
-            // 찾은 학기와 학수코드로 개설 강의 찾기
-            CourseOffering courseOffering = courseOfferingRepository
-                    .findBySemesterIdAndSubjectNumber(semester.getId(), key.haksuCode())
-                    .orElse(null);
+                // 찾은 학기와 학수코드로 개설 강의 찾기
+                CourseOffering courseOffering = courseOfferingRepository
+                        .findBySemesterIdAndSubjectNumber(semester.getId(), key.haksuCode())
+                        .orElse(null);
 
-            if (courseOffering == null) {
-                log.warn("강의 시간 정보에 해당하는 개설 강의를 찾을 수 없습니다. year={}, termCode={}, haksuCode={}",
-                        key.year(), key.termCode(), key.haksuCode());
-                continue;
+                if (courseOffering == null) {
+                    log.warn("강의 시간 정보에 해당하는 개설 강의를 찾을 수 없습니다. year={}, termCode={}, haksuCode={}",
+                            key.year(), key.termCode(), key.haksuCode());
+                    continue;
+                }
+
+                // 업데이트가 될 떄 기존 시간 정보를 지웠다가 다시 생성(이게 더 안전하고 효율적, 데이터가 적어서)
+                courseMeetingRepository.deleteAllByCourseOfferingId(courseOffering.getId());
+
+                // API로 받아온 값은 CourseOffering 필드에 맞게 변환
+                List<CourseMeeting> meetings = meetingItems.stream()
+                        .map(item -> CourseMeeting.create(
+                                courseOffering,
+                                item.roomName(),
+                                item.lectmName(),
+                                DayOfWeek.mapDay(item.dayName()),
+                                LocalTime.parse(item.lectmStart()),
+                                LocalTime.parse(item.lectmEnd())
+                        )).toList();
+
+                courseMeetingRepository.saveAll(meetings);
+                
+            } catch (Exception e) {
+                CourseMeetingGroupKey key = entry.getKey();
+                log.warn("강의 시간 동기화 스킵. year={}, termCode={}, haksuCode={}, reason={}",
+                        key.year(), key.termCode(), key.haksuCode(), e.getMessage());
             }
-
-            // 업데이트가 될 떄 기존 시간 정보를 지웠다가 다시 생성(이게 더 안전하고 효율적, 데이터가 적어서)
-            courseMeetingRepository.deleteAllByCourseOfferingId(courseOffering.getId());
-
-            // API로 받아온 값은 CourseOffering 필드에 맞게 변환
-            List<CourseMeeting> meetings = meetingItems.stream()
-                    .map(item -> CourseMeeting.create(
-                            courseOffering,
-                            item.roomName(),
-                            item.lectmName(),
-                            DayOfWeek.mapDay(item.dayName()),
-                            LocalTime.parse(item.lectmStart()),
-                            LocalTime.parse(item.lectmEnd())
-                    )).toList();
-
-            courseMeetingRepository.saveAll(meetings);
         }
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseOfferingService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseOfferingService.java
@@ -27,7 +27,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -46,16 +48,27 @@ public class CourseOfferingService {
     public Page<CourseOfferingResponseDto> getCourseOfferings(
             Integer year,
             SemesterTerm term,
-            Pageable pageable) {
+            Pageable pageable
+    ) {
         Semester semester = semesterRepository.findByYearAndTerm(year, term)
                 .orElseThrow(() -> new MyException(MyErrorCode.SEMESTER_NOT_FOUND));
 
-        return courseOfferingRepository.findAllBySemesterId(semester.getId(), pageable)
-                .map(courseOffering -> {
-                    List<CourseMeeting> meetings = courseMeetingRepository.findAllByCourseOfferingId(courseOffering.getId());
+        Page<CourseOffering> courseOfferings =
+                courseOfferingRepository.findAllBySemesterId(semester.getId(), pageable);
 
-                    return CourseOfferingResponseDto.from(courseOffering, meetings);
-                });
+        List<Long> courseOfferingIds = courseOfferings.getContent().stream().map(CourseOffering::getId).toList();
+
+        Map<Long, List<CourseMeeting>> meetingsByCourseOfferingId =
+                courseMeetingRepository.findAllByCourseOfferingIdIn(courseOfferingIds).stream()
+                        .collect(Collectors.groupingBy(
+                                meeting -> meeting.getCourseOffering().getId()
+                        ));
+
+        return courseOfferings.map(courseOffering -> CourseOfferingResponseDto.from(
+                        courseOffering,
+                        meetingsByCourseOfferingId.getOrDefault(courseOffering.getId(), List.of())
+                )
+        );
     }
 
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseOfferingSyncService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/service/CourseOfferingSyncService.java
@@ -36,7 +36,12 @@ public class CourseOfferingSyncService {
                 courseApiClient.fetchAllCourseOfferings(year, modDate);
 
         for (CourseOfferingApiItem item : items) {
-            courseOfferingService.upsertCourseOfferings(item);
+            try {
+                courseOfferingService.upsertCourseOfferings(item);
+            } catch (Exception e) {
+                log.warn("개설 강의 동기화 스킵. year={}, termCode={}, haksuCode={}, reason={}",
+                        item.year(), item.termCode(), item.haksuCode(), e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableItemApiSpecification.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableItemApiSpecification.java
@@ -85,15 +85,26 @@ public interface TimeTableItemApiSpecification {
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ResponseDto.class),
-                            examples = @ExampleObject(
-                                    name = "강의 시간 중복 응답 예시",
-                                    value = """
-                                            {
-                                              "data": null,
-                                              "msg": "동일한 시간의 시간표 요소가 존재합니다."
-                                            }
-                                            """
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "강의 시간 중복 응답 예시",
+                                            value = """
+                                                    {
+                                                      "data": null,
+                                                      "msg": "동일한 시간의 시간표 요소가 존재합니다."
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "동일 개설 강의 중복 응답 예시",
+                                            value = """
+                                                    {
+                                                      "data": null,
+                                                      "msg": "이미 시간표에 추가된 개설 강의입니다."
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             )
     })

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableItemApiSpecification.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/controller/TimeTableItemApiSpecification.java
@@ -28,9 +28,12 @@ public interface TimeTableItemApiSpecification {
             description = """
                     로그인한 사용자가 소유한 시간표에 강의 기반 시간표 요소를 추가합니다.
                     <br><br>
-                    요청한 개설 강의는 시간표와 같은 학기에 속해야 하며, 강의 시간 정보가 존재해야 합니다.
+                    요청한 개설 강의는 시간표와 같은 학기에 속해야 합니다.
                     <br>
-                    강의 시간이 같은 요청 안에서 겹치거나, 기존 시간표 요소와 겹치면 생성할 수 없습니다.
+                    개설 강의에 시간 정보가 있는 경우에만 시간 중복 검사를 수행합니다.
+                    강의 시간이 같은 강의 안에서 겹치거나, 기존 시간표 요소와 겹치면 생성할 수 없습니다.
+                    <br>
+                    온라인 강의 또는 시간 미정 강의처럼 시간 정보가 없는 개설 강의도 시간표 요소로 추가할 수 있습니다.
                     <br><br>
                     생성 응답은 시간표 요소의 최소 정보만 반환합니다.
                     화면 갱신에 필요한 강의명, 강의 시간 등 상세 정보는 시간표 상세 조회 API를 다시 호출해 조회합니다.
@@ -77,25 +80,8 @@ public interface TimeTableItemApiSpecification {
                     )
             ),
             @ApiResponse(
-                    responseCode = "404",
-                    description = "개설 강의의 시간 정보가 존재하지 않습니다.",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ResponseDto.class),
-                            examples = @ExampleObject(
-                                    name = "강의 시간 정보 없음 응답 예시",
-                                    value = """
-                                            {
-                                              "data": null,
-                                              "msg": "시간 정보가 존재하지 않습니다."
-                                            }
-                                            """
-                            )
-                    )
-            ),
-            @ApiResponse(
                     responseCode = "409",
-                    description = "개설 강의의 시간 정보가 같은 강의 안에서 겹치거나, 기존 시간표 요소와 겹칩니다.",
+                    description = "이미 같은 시간표에 추가된 개설 강의이거나, 개설 강의에 시간 정보가 있는 경우 강의 시간끼리 겹치거나 기존 시간표 요소와 시간이 겹칩니다.",
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ResponseDto.class),

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/model/TimeTableItem.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/model/TimeTableItem.java
@@ -17,7 +17,15 @@ import org.hibernate.annotations.Check;
         or
         (timetable_item_type = 'CUSTOM' and course_offering_id is null and custom_schedule_id is not null)
         """)
-@Table(name = "timetable_item")
+@Table(
+        name = "timetable_item",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_timetable_item_course",
+                        columnNames = {"timetable_id", "course_offering_id"}
+                )
+        }
+)
 public class TimeTableItem {
 
     @Id

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/repository/TimeTableItemRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/repository/TimeTableItemRepository.java
@@ -15,6 +15,8 @@ public interface TimeTableItemRepository extends JpaRepository<TimeTableItem, Lo
 
     List<TimeTableItem> findAllByTimeTableId(Long timeTableId);
 
+    boolean existsByTimeTableIdAndCourseOfferingId(Long timeTableId, Long courseOfferingId);
+
     @Query("""
             select case when count(item) > 0 then true else false end
             from TimeTableItem item

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
@@ -48,18 +48,23 @@ public class TimeTableItemService {
             Long timeTableId,
             Long courseOfferingId
     ) {
+        // 시간표 가져오기
         TimeTable timeTable = timeTableRepository.findById(timeTableId)
                 .orElseThrow(() -> new MyException(MyErrorCode.TIMETABLE_NOT_FOUND));
 
+        // 시간표 유저 검증
         validateOwner(memberId, timeTable);
 
+        // 개설 강의 가져오기
         CourseOffering courseOffering = courseOfferingRepository.findById(courseOfferingId)
                 .orElseThrow(() -> new MyException(MyErrorCode.COURSE_OFFERING_NOT_FOUND));
 
+        // 시간표의 학기와 개설 겅의 학기가 맞는지 검증
         if (!courseOffering.getSemester().getId().equals(timeTable.getSemester().getId())) {
             throw new MyException(MyErrorCode.NO_MATCH_SEMESTER);
         }
 
+        // 동일한 개설 강의 요소가 들어가는지 검증
         if (timeTableItemRepository.existsByTimeTableIdAndCourseOfferingId(timeTableId, courseOfferingId)) {
             throw new MyException(MyErrorCode.DUPLICATE_TIMETABLE_COURSE_ITEM);
         }
@@ -143,6 +148,7 @@ public class TimeTableItemService {
             throw new MyException(MyErrorCode.NO_CUSTOM_ITEM_IN_TIMETABLE);
         }
 
+        // 수정하려는 시간표 요소가 커스텀인지 아닌지 검증
         if (updatetimeTableItem.getType() != TimeTableItemType.CUSTOM)
             throw new MyException(MyErrorCode.NO_CUSTOM_ITEM);
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableItemService.java
@@ -60,18 +60,18 @@ public class TimeTableItemService {
             throw new MyException(MyErrorCode.NO_MATCH_SEMESTER);
         }
 
-        // 생성용
-        List<CourseMeeting> meetings = courseMeetingRepository.findAllByCourseOfferingId(courseOffering.getId());
-        if (meetings.isEmpty()) {
-            throw new MyException(MyErrorCode.MEETINGS_NOT_FOUND);
+        if (timeTableItemRepository.existsByTimeTableIdAndCourseOfferingId(timeTableId, courseOfferingId)) {
+            throw new MyException(MyErrorCode.DUPLICATE_TIMETABLE_COURSE_ITEM);
         }
 
-        // 검증용
-        List<TimeSlot> timeSlots = toTimeSlots(meetings);
+        // 생성용
+        List<CourseMeeting> meetings = courseMeetingRepository.findAllByCourseOfferingId(courseOffering.getId());
+        if (!meetings.isEmpty()) {
+            List<TimeSlot> timeSlots = toTimeSlots(meetings);
 
-        // 중복 일정 검증
-        validateNoRequestTimeConflict(timeSlots);
-        validateNoDBTimeConflict(timeTableId, timeSlots);
+            validateNoRequestTimeConflict(timeSlots);
+            validateNoDBTimeConflict(timeTableId, timeSlots);
+        }
 
         TimeTableItem courseItem = TimeTableItem.createForCourse(memo, timeTable, courseOffering);
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
@@ -98,6 +98,7 @@ public enum MyErrorCode {
     TIMETABLE_ITEM_TIME_CONFLICT(HttpStatus.CONFLICT, "시간표 요소의 시간이 중복입니다."),
     TIMETABLE_ITEM_TIME_REQUEST_CONFLICT(HttpStatus.CONFLICT, "동일한 시간의 시간표 요소를 추가할 수 없습니다."),
     TIMETABLE_ITEM_TIME_DB_CONFLICT(HttpStatus.CONFLICT, "동일한 시간의 시간표 요소가 존재합니다."),
+    DUPLICATE_TIMETABLE_COURSE_ITEM(HttpStatus.CONFLICT, "이미 시간표에 추가된 개설 강의입니다."),
     PRIVATE_TIMETABLE(HttpStatus.FORBIDDEN, "비공개된 시간표입니다."),
     NOT_READABLE_TIMETABLE(HttpStatus.FORBIDDEN, "친구가 아닌 사용자의 시간표를 읽을 수 없습니다."),
     PRIMARY_TIMETABLE_NOT_FOUND(HttpStatus.NOT_FOUND, "대표 시간표가 존재하지 않습니다."),


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- CourseOfferingService.getCourseOfferings에서 개설강의마다 CourseMeeting을 따로 조회하던 구조를 수정
- CourseMeetingRepository.findAllByCourseOfferingIdIn(...)을 추가해서 현재 페이지의 개설강의 id 목록으로 CourseMeeting을 한 번에 조회하도록 변경
- 조회한 CourseMeeting을 courseOfferingId 기준으로 그룹핑해서 응답 DTO에 매핑
- @EntityGraph 적용해 lazy loading 줄임
- 같은 시간표에 같은 개설강의를 중복 추가하지 못하도록 검증 로직을 유지/반영
- A_MAP_COURSE_TIMETABLE에는 존재하지만,  A_MAP_COURSE_INFO에는 매칭되는 CourseOffering이 없는 데이터가 있을 수 있어서 기존처럼 예외로 동기화 전체를 실패시키지 않도록 수정
- 개설강의는 있지만 시간 정보가 없는 경우: 정상 저장, 시간표 요소 추가 가능
- 시간 정보는 있지만 매칭되는 개설강의가 없는 경우: 로그 남기고 스킵
- 시간 정보가 있는 개설강의: CourseMeeting 저장 후 시간표 상세/추가 로직에서 활용

## 🤔 추후 작업 사항

- ex) 성능 개선 필요