### PR TITLE
feat: 상세 시간표 조회할 때 시간테이블이 쪼개지지않고 연강 처리되게 수정

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timeTableItem/CourseTimeTableItemResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timeTableItem/CourseTimeTableItemResponseDto.java
@@ -1,8 +1,8 @@
 package kr.inuappcenterportal.inuportal.domain.timeTable.dto.response.timeTableItem;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import kr.inuappcenterportal.inuportal.domain.course.dto.courseMeeting.CourseMeetingResponseDto;
 import kr.inuappcenterportal.inuportal.domain.course.model.Course;
-import kr.inuappcenterportal.inuportal.domain.course.model.CourseMeeting;
 import kr.inuappcenterportal.inuportal.domain.course.model.CourseOffering;
 import kr.inuappcenterportal.inuportal.domain.timeTable.enums.Visibility;
 
@@ -26,7 +26,7 @@ public record CourseTimeTableItemResponseDto(
 ) {
     public static CourseTimeTableItemResponseDto of(
             CourseOffering courseOffering,
-            List<CourseMeeting> meetings
+            List<CourseMeetingResponseDto> meetings
     ) {
         Course course = courseOffering.getCourse();
 
@@ -45,7 +45,7 @@ public record CourseTimeTableItemResponseDto(
 
     public static CourseTimeTableItemResponseDto of(
             CourseOffering courseOffering,
-            List<CourseMeeting> meetings,
+            List<CourseMeetingResponseDto> meetings,
             Visibility visibility
     ) {
         boolean masked = visibility == Visibility.PROTECTED;

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timeTableItem/TimeTableMeetingResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/dto/response/timeTableItem/TimeTableMeetingResponseDto.java
@@ -2,8 +2,8 @@ package kr.inuappcenterportal.inuportal.domain.timeTable.dto.response.timeTableI
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import kr.inuappcenterportal.inuportal.domain.course.dto.courseMeeting.CourseMeetingResponseDto;
 import kr.inuappcenterportal.inuportal.domain.course.enums.courseOffering.DayOfWeek;
-import kr.inuappcenterportal.inuportal.domain.course.model.CourseMeeting;
 import kr.inuappcenterportal.inuportal.domain.customSchedule.model.CustomScheduleMeeting;
 
 import java.time.LocalTime;
@@ -27,14 +27,14 @@ public record TimeTableMeetingResponseDto(
 
     // 강의 시간표 요소
     // CourseMeeting을 TimeTableMeetingResponseDto으로 바꾸는 정적 팩토리 메서드
-    public static TimeTableMeetingResponseDto from(CourseMeeting meeting) {
+    public static TimeTableMeetingResponseDto from(CourseMeetingResponseDto meeting) {
         return new TimeTableMeetingResponseDto(
-                meeting.getId(),
-                meeting.getLocation(),
-                meeting.getSequence(),
-                meeting.getDay(),
-                meeting.getStartTime(),
-                meeting.getEndTime()
+                meeting.id(),
+                meeting.location(),
+                meeting.sequence(),
+                meeting.day(),
+                meeting.startTime(),
+                meeting.endTime()
         );
     }
 
@@ -50,14 +50,15 @@ public record TimeTableMeetingResponseDto(
         );
     }
 
-    public static TimeTableMeetingResponseDto from(CourseMeeting meeting, boolean masked) {
+    // 친구용
+    public static TimeTableMeetingResponseDto from(CourseMeetingResponseDto meeting, boolean masked) {
         return new TimeTableMeetingResponseDto(
-                masked ? null : meeting.getId(),
-                masked ? null : meeting.getLocation(),
-                masked ? null : meeting.getSequence(),
-                meeting.getDay(),
-                meeting.getStartTime(),
-                meeting.getEndTime()
+                masked ? null : meeting.id(),
+                masked ? null : meeting.location(),
+                masked ? null : meeting.sequence(),
+                meeting.day(),
+                meeting.startTime(),
+                meeting.endTime()
         );
     }
 

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/timeTable/service/TimeTableService.java
@@ -1,8 +1,10 @@
 package kr.inuappcenterportal.inuportal.domain.timeTable.service;
 
+import kr.inuappcenterportal.inuportal.domain.course.dto.courseMeeting.CourseMeetingResponseDto;
 import kr.inuappcenterportal.inuportal.domain.course.model.CourseMeeting;
 import kr.inuappcenterportal.inuportal.domain.course.model.CourseOffering;
 import kr.inuappcenterportal.inuportal.domain.course.repository.CourseMeetingRepository;
+import kr.inuappcenterportal.inuportal.domain.course.service.CourseMeetingService;
 import kr.inuappcenterportal.inuportal.domain.customSchedule.model.CustomSchedule;
 import kr.inuappcenterportal.inuportal.domain.customSchedule.model.CustomScheduleMeeting;
 import kr.inuappcenterportal.inuportal.domain.customSchedule.repository.CustomScheduleMeetingRepository;
@@ -48,6 +50,7 @@ public class TimeTableService {
     private final CourseMeetingRepository courseMeetingRepository;
     private final CustomScheduleMeetingRepository customScheduleMeetingRepository;
     private final FriendService friendService;
+    private final CourseMeetingService courseMeetingService;
 
 
     /**
@@ -81,9 +84,12 @@ public class TimeTableService {
                 List<CourseMeeting> meetings =
                         courseMeetingRepository.findAllByCourseOfferingId(courseOffering.getId());
 
+                List<CourseMeetingResponseDto> mergedMeetings =
+                        courseMeetingService.mergeContinuousMeetings(meetings);
+
                 yield TimeTableDetailItemResponseDto.ofCourse(
                         item,
-                        CourseTimeTableItemResponseDto.of(courseOffering, meetings)
+                        CourseTimeTableItemResponseDto.of(courseOffering, mergedMeetings)
                 );
             }
 
@@ -366,9 +372,12 @@ public class TimeTableService {
                 List<CourseMeeting> meetings =
                         courseMeetingRepository.findAllByCourseOfferingId(courseOffering.getId());
 
+                List<CourseMeetingResponseDto> mergedMeetings =
+                        courseMeetingService.mergeContinuousMeetings(meetings);
+
                 yield TimeTableDetailItemResponseDto.ofCourse(
                         item,
-                        CourseTimeTableItemResponseDto.of(courseOffering, meetings, visibility),
+                        CourseTimeTableItemResponseDto.of(courseOffering, mergedMeetings, visibility),
                         visibility
                 );
             }


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- 시간표 상세 조회할 때 시간테이블이 쪼개지지않고 연강 처리되게 수정

## 🤔 추후 작업 사항

- ex) 성능 개선 필요