### PR TITLE
✨ feat: 친구추가 URL/QR 초대 코드 API 추가

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/controller/FriendController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/controller/FriendController.java
@@ -4,10 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import kr.inuappcenterportal.inuportal.domain.member.dto.FriendInviteCodeResponseDto;
+import kr.inuappcenterportal.inuportal.domain.member.dto.FriendInvitePreviewResponseDto;
 import kr.inuappcenterportal.inuportal.domain.member.dto.FriendRequestDto;
 import kr.inuappcenterportal.inuportal.domain.member.dto.FriendResponseDto;
 import kr.inuappcenterportal.inuportal.domain.member.dto.FriendAliasRequestDto;
 import kr.inuappcenterportal.inuportal.domain.member.dto.MemberProfileResponseDto;
+import kr.inuappcenterportal.inuportal.domain.member.service.FriendInviteService;
 import kr.inuappcenterportal.inuportal.domain.member.service.FriendService;
 import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +29,7 @@ import java.util.List;
 public class FriendController {
 
     private final FriendService friendService;
+    private final FriendInviteService friendInviteService;
 
     @Operation(summary = "친구 신청 (닉네임 기반)")
     @PostMapping("/request")
@@ -95,6 +99,36 @@ public class FriendController {
         Long memberId = Long.parseLong(userDetails.getUsername());
         friendService.updateFriendAlias(memberId, friendId, requestDto);
         return ResponseEntity.ok(ResponseDto.of(null));
+    }
+
+    @Operation(summary = "내 친구추가 링크(초대 코드) 조회", description = "유효한 코드가 있으면 그대로, 없으면 새로 발급해 반환합니다. QR/URL 공유에 사용합니다.")
+    @SecurityRequirement(name = "Auth")
+    @GetMapping("/invite-code")
+    public ResponseEntity<ResponseDto<FriendInviteCodeResponseDto>> getInviteCode(@AuthenticationPrincipal UserDetails userDetails) {
+        Long memberId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(ResponseDto.of(friendInviteService.getOrCreateInviteCode(memberId), "친구추가 링크 조회 성공"));
+    }
+
+    @Operation(summary = "내 친구추가 링크 재발급", description = "기존 링크를 즉시 폐기하고 새 코드를 발급합니다.")
+    @SecurityRequirement(name = "Auth")
+    @PostMapping("/invite-code/refresh")
+    public ResponseEntity<ResponseDto<FriendInviteCodeResponseDto>> refreshInviteCode(@AuthenticationPrincipal UserDetails userDetails) {
+        Long memberId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(ResponseDto.of(friendInviteService.refreshInviteCode(memberId), "친구추가 링크 재발급 성공"));
+    }
+
+    @Operation(summary = "친구추가 링크 미리보기", description = "초대 코드의 주인이 누구인지 확인합니다. 비로그인 상태에서도 호출할 수 있습니다.")
+    @GetMapping("/invite/{code}")
+    public ResponseEntity<ResponseDto<FriendInvitePreviewResponseDto>> getInvitePreview(@PathVariable String code) {
+        return ResponseEntity.ok(ResponseDto.of(friendInviteService.getInvitePreview(code), "친구추가 링크 조회 성공"));
+    }
+
+    @Operation(summary = "친구추가 링크 수락", description = "링크 주인과 즉시 친구가 됩니다. 별도 수락 절차가 없습니다.")
+    @SecurityRequirement(name = "Auth")
+    @PostMapping("/invite/{code}/accept")
+    public ResponseEntity<ResponseDto<FriendResponseDto>> acceptInvite(@PathVariable String code, @AuthenticationPrincipal UserDetails userDetails) {
+        Long memberId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(ResponseDto.of(friendInviteService.acceptInvite(memberId, code), "친구추가 성공"));
     }
 
     @Operation(summary = "친구 프로필 조회", description = "친구 관계 ID를 기반으로 상대방의 상세 프로필을 조회합니다.")

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/dto/FriendInviteCodeResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/dto/FriendInviteCodeResponseDto.java
@@ -1,0 +1,15 @@
+package kr.inuappcenterportal.inuportal.domain.member.dto;
+
+import lombok.Builder;
+
+/**
+ * 내 친구추가 초대 코드.
+ *
+ * @param code 초대 코드(난수). 클라이언트가 배포 환경에 맞는 origin 으로 링크를 조립할 때 쓴다.
+ * @param url  서버 설정 기준으로 조립한 초대 URL. 공유 문구 등 서버 발신 채널에서 쓰는 정규 링크.
+ */
+public record FriendInviteCodeResponseDto(String code, String url) {
+    @Builder
+    public FriendInviteCodeResponseDto {
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/dto/FriendInvitePreviewResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/dto/FriendInvitePreviewResponseDto.java
@@ -1,0 +1,13 @@
+package kr.inuappcenterportal.inuportal.domain.member.dto;
+
+import lombok.Builder;
+
+/**
+ * 초대 링크를 연 사람에게 "누구의 링크인지" 보여주기 위한 미리보기.
+ * 비로그인 상태에서도 조회되므로 학번은 마스킹된 값만, 회원 식별자는 담지 않는다.
+ */
+public record FriendInvitePreviewResponseDto(String nickname, String studentId, Long fireId) {
+    @Builder
+    public FriendInvitePreviewResponseDto {
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/model/FriendInviteCode.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/model/FriendInviteCode.java
@@ -1,0 +1,58 @@
+package kr.inuappcenterportal.inuportal.domain.member.model;
+
+import jakarta.persistence.*;
+import kr.inuappcenterportal.inuportal.global.model.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 친구추가 URL/QR에 실리는 초대 코드.
+ * 닉네임(학번일 수 있음)을 URL에 노출하지 않기 위해, 회원 정보와 아무런 수학적 연관이 없는
+ * 난수 코드를 발급해 이 테이블로만 회원과 연결한다.
+ * 회원당 여러 행을 가질 수 있고(1:N), 재발급 시 기존 행을 revoke 처리한다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "friend_invite_code",
+        indexes = {
+                @Index(name = "idx_friend_invite_code_member", columnList = "member_id"),
+                @Index(name = "idx_friend_invite_code_code", columnList = "code", unique = true)
+        }
+)
+public class FriendInviteCode extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(nullable = false, unique = true, length = 32)
+    private String code;
+
+    /** null 이면 유효한 코드. 재발급 시 시각이 기록되며 그 즉시 링크가 무효화된다. */
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Builder
+    public FriendInviteCode(Member member, String code) {
+        this.member = member;
+        this.code = code;
+    }
+
+    public void revoke(LocalDateTime now) {
+        this.revokedAt = now;
+    }
+
+    public boolean isRevoked() {
+        return this.revokedAt != null;
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/repository/FriendInviteCodeRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/repository/FriendInviteCodeRepository.java
@@ -1,0 +1,19 @@
+package kr.inuappcenterportal.inuportal.domain.member.repository;
+
+import kr.inuappcenterportal.inuportal.domain.member.model.FriendInviteCode;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FriendInviteCodeRepository extends JpaRepository<FriendInviteCode, Long> {
+
+    Optional<FriendInviteCode> findByCodeAndRevokedAtIsNull(String code);
+
+    Optional<FriendInviteCode> findFirstByMemberAndRevokedAtIsNullOrderByIdDesc(Member member);
+
+    List<FriendInviteCode> findAllByMemberAndRevokedAtIsNull(Member member);
+
+    boolean existsByCode(String code);
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendInviteService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendInviteService.java
@@ -1,0 +1,186 @@
+package kr.inuappcenterportal.inuportal.domain.member.service;
+
+import kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType;
+import kr.inuappcenterportal.inuportal.domain.firebase.service.FcmAsyncService;
+import kr.inuappcenterportal.inuportal.domain.member.dto.FriendInviteCodeResponseDto;
+import kr.inuappcenterportal.inuportal.domain.member.dto.FriendInvitePreviewResponseDto;
+import kr.inuappcenterportal.inuportal.domain.member.dto.FriendResponseDto;
+import kr.inuappcenterportal.inuportal.domain.member.enums.FriendStatus;
+import kr.inuappcenterportal.inuportal.domain.member.model.Friend;
+import kr.inuappcenterportal.inuportal.domain.member.model.FriendInviteCode;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.member.repository.BlockRepository;
+import kr.inuappcenterportal.inuportal.domain.member.repository.FriendInviteCodeRepository;
+import kr.inuappcenterportal.inuportal.domain.member.repository.FriendRepository;
+import kr.inuappcenterportal.inuportal.domain.member.repository.MemberRepository;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 친구추가 URL/QR 초대 코드 발급 및 수락.
+ *
+ * <p>링크 소유자는 링크를 만든 시점에 이미 친구 추가에 동의한 것으로 보므로, 링크를 통해 들어온
+ * 상대는 별도 승인 없이 곧바로 {@link FriendStatus#ACCEPTED} 상태의 친구가 된다.
+ * 그 대신 링크가 유출됐을 때를 대비해 사용자가 직접 재발급(=기존 링크 폐기)할 수 있다.
+ */
+@Service
+@RequiredArgsConstructor
+public class FriendInviteService {
+
+    /** URL/QR에 그대로 실리므로 대소문자 혼동이 적고 인코딩이 필요 없는 문자만 사용한다. */
+    private static final String CODE_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int CODE_LENGTH = 22;
+    private static final int MAX_CODE_GENERATION_ATTEMPTS = 5;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final FriendInviteCodeRepository friendInviteCodeRepository;
+    private final FriendRepository friendRepository;
+    private final MemberRepository memberRepository;
+    private final BlockRepository blockRepository;
+    private final FcmAsyncService fcmAsyncService;
+    private final Clock clock;
+
+    @Value("${friendInviteBaseUrl:https://intip.inuappcenter.kr}")
+    private String friendInviteBaseUrl;
+
+    /** 유효한 코드가 있으면 그대로, 없으면 새로 발급해서 돌려준다. */
+    @Transactional
+    public FriendInviteCodeResponseDto getOrCreateInviteCode(Long memberId) {
+        Member member = findMember(memberId);
+
+        FriendInviteCode inviteCode = friendInviteCodeRepository
+                .findFirstByMemberAndRevokedAtIsNullOrderByIdDesc(member)
+                .orElseGet(() -> issueCode(member));
+
+        return toResponse(inviteCode);
+    }
+
+    /** 기존 코드를 모두 폐기하고 새 코드를 발급한다. 유출된 링크를 끊는 유일한 수단이다. */
+    @Transactional
+    public FriendInviteCodeResponseDto refreshInviteCode(Long memberId) {
+        Member member = findMember(memberId);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        List<FriendInviteCode> activeCodes = friendInviteCodeRepository.findAllByMemberAndRevokedAtIsNull(member);
+        activeCodes.forEach(activeCode -> activeCode.revoke(now));
+
+        return toResponse(issueCode(member));
+    }
+
+    /**
+     * 초대 링크를 연 사람에게 보여줄 링크 소유자 정보.
+     * 비로그인 상태에서도 "누구의 링크인지" 확인하고 로그인 여부를 결정할 수 있어야 하므로 인증을 요구하지 않는다.
+     */
+    @Transactional(readOnly = true)
+    public FriendInvitePreviewResponseDto getInvitePreview(String code) {
+        Member owner = findActiveCode(code).getMember();
+
+        return FriendInvitePreviewResponseDto.builder()
+                .nickname(owner.getNickname())
+                .studentId(owner.getMaskedStudentId())
+                .fireId(owner.getFireId())
+                .build();
+    }
+
+    /** 초대 코드를 수락해 즉시 친구가 된다. */
+    @Transactional
+    public FriendResponseDto acceptInvite(Long memberId, String code) {
+        Member accepter = findMember(memberId);
+        Member owner = findActiveCode(code).getMember();
+
+        if (accepter.getId().equals(owner.getId())) {
+            throw new MyException(MyErrorCode.NOT_SELF_FRIEND_REQUEST);
+        }
+
+        if (blockRepository.existsByBlockerAndBlocked(accepter, owner) ||
+                blockRepository.existsByBlockerAndBlocked(owner, accepter)) {
+            throw new MyException(MyErrorCode.USER_NOT_FOUND);
+        }
+
+        Friend friend = findExistingFriendship(accepter, owner)
+                .map(existing -> {
+                    // 이미 친구인 상태에서 링크를 또 열었을 때. 새로 맺을 것이 없으니 알림도 보내지 않는다.
+                    if (existing.getStatus() == FriendStatus.ACCEPTED) {
+                        throw new MyException(MyErrorCode.ALREADY_FRIEND_OR_REQUESTED);
+                    }
+                    // 이미 대기 중이던 요청이 있으면 링크 수락으로 갈음한다.
+                    existing.accept();
+                    return existing;
+                })
+                .orElseGet(() -> friendRepository.save(Friend.builder()
+                        .requester(accepter)
+                        .receiver(owner)
+                        .status(FriendStatus.ACCEPTED)
+                        .build()));
+
+        fcmAsyncService.sendAsyncTrackedNotification(
+                List.of(owner.getId()),
+                "친구 추가",
+                accepter.getNickname() + "님과 친구가 되었습니다.",
+                FcmMessageType.FRIEND,
+                friend.getId(),
+                "/friend/list");
+
+        return FriendResponseDto.builder()
+                .friendId(friend.getId())
+                .friendMemberId(owner.getId())
+                .nickname(owner.getNickname())
+                .studentId(owner.getMaskedStudentId())
+                .fireId(owner.getFireId())
+                .build();
+    }
+
+    private Optional<Friend> findExistingFriendship(Member accepter, Member owner) {
+        return friendRepository.findByRequesterAndReceiver(accepter, owner)
+                .or(() -> friendRepository.findByRequesterAndReceiver(owner, accepter));
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MyException(MyErrorCode.USER_NOT_FOUND));
+    }
+
+    private FriendInviteCode findActiveCode(String code) {
+        return friendInviteCodeRepository.findByCodeAndRevokedAtIsNull(code)
+                .orElseThrow(() -> new MyException(MyErrorCode.NOT_FOUND_FRIEND_INVITE_CODE));
+    }
+
+    private FriendInviteCode issueCode(Member member) {
+        for (int attempt = 0; attempt < MAX_CODE_GENERATION_ATTEMPTS; attempt++) {
+            String candidate = generateCode();
+            if (!friendInviteCodeRepository.existsByCode(candidate)) {
+                return friendInviteCodeRepository.save(FriendInviteCode.builder()
+                        .member(member)
+                        .code(candidate)
+                        .build());
+            }
+        }
+        throw new MyException(MyErrorCode.FAIL_CREATE_FRIEND_INVITE_CODE);
+    }
+
+    private String generateCode() {
+        StringBuilder builder = new StringBuilder(CODE_LENGTH);
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            builder.append(CODE_ALPHABET.charAt(RANDOM.nextInt(CODE_ALPHABET.length())));
+        }
+        return builder.toString();
+    }
+
+    private FriendInviteCodeResponseDto toResponse(FriendInviteCode inviteCode) {
+        return FriendInviteCodeResponseDto.builder()
+                .code(inviteCode.getCode())
+                .url(friendInviteBaseUrl + "/friend/invite/" + inviteCode.getCode())
+                .build();
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
@@ -40,6 +40,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 최우선 허용 설정
                         .requestMatchers(HttpMethod.GET, "/api/chat-rooms/*/messages/public").permitAll()
+                        // 친구추가 링크는 비로그인 상태에서도 "누구의 링크인지" 미리보기가 가능해야 한다.
+                        .requestMatchers(HttpMethod.GET, "/api/friends/invite/*").permitAll()
                         .requestMatchers("/swagger", "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**", "/images/**", "/actuator/**", "/ws-chat/**", "/api/search", "/api/notices", "/api/notices/**", "/api/schedules", "/api/schedules/**", "/error").permitAll()
 
                         // 공통 GET 허용 설정

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
@@ -118,6 +118,8 @@ public enum MyErrorCode {
     NOT_FOUND_FRIEND_REQUEST(HttpStatus.NOT_FOUND, "존재하지 않는 친구 요청입니다."),
     ALREADY_FRIEND_OR_REQUESTED(HttpStatus.CONFLICT, "이미 친구이거나 요청 대기 중입니다."),
     NOT_SELF_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
+    NOT_FOUND_FRIEND_INVITE_CODE(HttpStatus.NOT_FOUND, "유효하지 않은 친구추가 링크입니다."),
+    FAIL_CREATE_FRIEND_INVITE_CODE(HttpStatus.INTERNAL_SERVER_ERROR, "친구추가 링크 생성에 실패했습니다."),
     NOT_SELF_BLOCK(HttpStatus.BAD_REQUEST, "자기 자신을 차단할 수 없습니다."),
     NOT_SELF_CHAT(HttpStatus.BAD_REQUEST, "자기 자신과는 채팅방을 만들 수 없습니다."),
     HAS_NOT_FRIEND_AUTHORIZATION(HttpStatus.FORBIDDEN, "친구 관련 작업을 수행할 권한이 없습니다."),


### PR DESCRIPTION
## 📎 관련 이슈

- 해당 없음 (별도 이슈 미등록)

## 📄 설명

친구추가를 닉네임 검색 외에 **URL/QR 링크**로도 할 수 있게 하는 서버 API입니다.

닉네임이 학번인 경우가 있어 링크에 그대로 실으면 개인정보가 노출됩니다. 그래서 회원 정보와 수학적 연관이 전혀 없는 **난수 코드**(SecureRandom, base62 22자)를 발급하고, 새 테이블 `friend_invite_code` 로만 회원과 연결합니다. 코드에서 학번·닉네임을 역산할 수 없습니다.

### 엔드포인트

| Method | Path | 인증 | 설명 |
| --- | --- | --- | --- |
| GET | `/api/friends/invite-code` | 필요 | 유효한 코드가 있으면 그대로, 없으면 새로 발급 |
| POST | `/api/friends/invite-code/refresh` | 필요 | 기존 코드 전부 폐기 후 재발급 |
| GET | `/api/friends/invite/{code}` | **불필요** | 링크 주인 미리보기 (닉네임 / 마스킹 학번 / fireId) |
| POST | `/api/friends/invite/{code}/accept` | 필요 | 링크 주인과 **즉시 친구 성립** |

### 설계 메모

- **즉시 ACCEPTED**: 링크를 만든 시점에 소유자가 이미 친구 추가에 동의한 것으로 봅니다. 받는 쪽이 링크를 열고 누르면 곧바로 친구가 되고, 소유자에게는 "친구가 되었습니다" FCM만 갑니다.
- **만료 없음 + 수동 재발급**: 링크가 유출됐을 때 끊는 수단은 재발급입니다. `refresh` 호출 시 해당 회원의 유효 코드를 전부 `revoked_at` 처리합니다. 회원당 여러 행(1:N)이므로 과거 코드 이력이 남습니다.
- **미리보기 permitAll**: 비로그인 상태에서도 "누구의 링크인지" 보고 로그인 여부를 정할 수 있어야 해서 `GET /api/friends/invite/{code}` 만 인증을 뺐습니다. `SecurityConfig` 최우선 허용 블록에 넣어 기존 `/api/friends/**` 규칙보다 먼저 매칭되게 했습니다. 응답에는 마스킹 학번만 담고 memberId는 넣지 않습니다.
- **기존 요청과의 관계**: 이미 PENDING 요청이 있으면 링크 수락으로 갈음해 ACCEPTED로 올립니다. 이미 친구면 `ALREADY_FRIEND_OR_REQUESTED` 로 막습니다. 자기 자신·차단 관계는 기존 `FriendService` 예외를 그대로 씁니다.
- **URL 조립**: `@Value("${friendInviteBaseUrl:https://intip.inuappcenter.kr}")` 로 기본값을 둬 프로퍼티 추가 없이도 배포가 깨지지 않습니다. 프론트는 테스트/운영 도메인이 갈리므로 응답의 `code` 로 `window.location.origin` 기준 링크를 직접 조립합니다.

## 🤔 추후 작업 사항

- `friend_invite_code` 는 `ddl-auto` 로 생성됩니다. 운영 DDL을 따로 관리한다면 테이블 추가가 필요합니다.
- QR **스캔**(읽는 쪽)은 이번 범위 밖입니다. 상대는 휴대폰 기본 카메라로 URL을 열게 됩니다.
- 프론트 연동(`inu-portal-web`)은 별도 PR로 올라갑니다.

https://claude.ai/code/session_014nmu2j1MTFEU4jRKNAYQHB
