### PR TITLE
fix: 푸시 알림별 이동 경로(path) 지정 — FRIEND 경로 오류 및 관리자 발송 누락 (#341)

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/AdminNotificationDispatch.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/AdminNotificationDispatch.java
@@ -8,7 +8,8 @@ public record AdminNotificationDispatch(
         String title,
         String content,
         Map<String, Long> tokenAndMemberId,
-        List<Long> targetMemberIds
+        List<Long> targetMemberIds,
+        String path
 ) {
     public boolean hasTarget() {
         return !tokenAndMemberId.isEmpty();

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/req/AdminNotificationRequest.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/dto/req/AdminNotificationRequest.java
@@ -27,7 +27,10 @@ public record AdminNotificationRequest(
 
         @Schema(description = "Notification content", example = "Please join the survey event.")
         @NotBlank(message = "Content must not be blank.")
-        String content
+        String content,
+
+        @Schema(description = "Path to navigate to when the notification is tapped. Full URL for web, relative path for in-app routes.", example = "/board/1")
+        String path
 
 ) {
     public AdminNotificationTargetType resolveTargetType() {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -245,7 +245,8 @@ public class FcmService {
                 request.title(),
                 request.content(),
                 Map.copyOf(notificationTargets.tokenAndMemberId()),
-                List.copyOf(notificationTargets.targetMemberIds())
+                List.copyOf(notificationTargets.targetMemberIds()),
+                request.path()
         );
     }
 
@@ -276,7 +277,8 @@ public class FcmService {
                     dispatch.title(),
                     dispatch.content(),
                     FcmMessageType.GENERAL,
-                    null
+                    null,
+                    dispatch.path()
             );
 
             // 4. 최종 상태 업데이트

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/FriendService.java
@@ -59,7 +59,7 @@ public class FriendService {
                 .build();
         friendRepository.save(friend);
 
-        fcmAsyncService.sendAsyncTrackedNotification(List.of(receiver.getId()), "친구 요청", requester.getNickname() + "님이 친구 요청을 보냈습니다.", FcmMessageType.FRIEND, friend.getId(), "/friend/list");
+        fcmAsyncService.sendAsyncTrackedNotification(List.of(receiver.getId()), "친구 요청", requester.getNickname() + "님이 친구 요청을 보냈습니다.", FcmMessageType.FRIEND, friend.getId(), "/chat/list?category=친구");
     }
 
     @Transactional(readOnly = true)
@@ -124,7 +124,7 @@ public class FriendService {
 
         friend.accept();
 
-        fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 수락", friend.getReceiver().getNickname() + "님이 친구 요청을 수락했습니다.", FcmMessageType.FRIEND, friend.getId(), "/friend/list");
+        fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 수락", friend.getReceiver().getNickname() + "님이 친구 요청을 수락했습니다.", FcmMessageType.FRIEND, friend.getId(), "/chat/list?category=친구");
     }
 
     @Transactional
@@ -137,7 +137,7 @@ public class FriendService {
         }
 
         if (friend.getStatus() == FriendStatus.PENDING && friend.getReceiver().getId().equals(memberId)) {
-            fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 요청 결과", "친구 요청이 거절되었습니다.", FcmMessageType.FRIEND, friend.getId(), "/friend/list");
+            fcmAsyncService.sendAsyncTrackedNotification(List.of(friend.getRequester().getId()), "친구 요청 결과", "친구 요청이 거절되었습니다.", FcmMessageType.FRIEND, friend.getId(), "/chat/list?category=친구");
         }
 
         friendRepository.delete(friend);

--- a/src/test/java/kr/inuappcenterportal/inuportal/firebase/SendToMembersTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/firebase/SendToMembersTest.java
@@ -81,7 +81,7 @@ class SendToMembersTest {
     @Test
     void prepareAdminNotification_usesAllTokensAndAllMembersForDefaultSend() {
         AdminNotificationRequest request =
-                new AdminNotificationRequest(null, List.of(), List.of(), List.of(), "Test Title", "Test Content");
+                new AdminNotificationRequest(null, List.of(), List.of(), List.of(), "Test Title", "Test Content", null);
 
         FcmToken linkedToken = new FcmToken(69L, "sample_token_69", "iphone");
         FcmToken unlinkedToken = new FcmToken(null, "sample_token_guest", "android");
@@ -109,9 +109,29 @@ class SendToMembersTest {
     }
 
     @Test
+    void prepareAdminNotification_carriesPathThrough() {
+        AdminNotificationRequest request =
+                new AdminNotificationRequest(null, List.of(), List.of(), List.of(), "Test Title", "Test Content", "/board/1");
+
+        FcmToken linkedToken = new FcmToken(69L, "sample_token_69", "iphone");
+
+        when(fcmTokenRepository.findAllTokens()).thenReturn(List.of(linkedToken));
+        when(memberRepository.findAllIds()).thenReturn(List.of(69L));
+        when(fcmMessageRepository.saveAndFlush(any(FcmMessage.class))).thenAnswer(invocation -> {
+            FcmMessage message = invocation.getArgument(0);
+            ReflectionTestUtils.setField(message, "id", 1L);
+            return message;
+        });
+
+        AdminNotificationDispatch dispatch = fcmService.prepareAdminNotification(request);
+
+        assertThat(dispatch.path()).isEqualTo("/board/1");
+    }
+
+    @Test
     void prepareAdminNotification_filtersLoggedInTokensAndMembers() {
         AdminNotificationRequest request =
-                new AdminNotificationRequest(AdminNotificationTargetType.LOGGED_IN, List.of(), List.of(), List.of(), "Test Title", "Test Content");
+                new AdminNotificationRequest(AdminNotificationTargetType.LOGGED_IN, List.of(), List.of(), List.of(), "Test Title", "Test Content", null);
 
         FcmToken fcmToken1 = new FcmToken(69L, "sample_token_69", "iphone");
         FcmToken fcmToken2 = new FcmToken(96L, "sample_token_96", "android");
@@ -135,7 +155,7 @@ class SendToMembersTest {
     @Test
     void prepareAdminNotification_filtersLoggedOutTokensAndMembers() {
         AdminNotificationRequest request =
-                new AdminNotificationRequest(AdminNotificationTargetType.LOGGED_OUT, List.of(), List.of(), List.of(), "Test Title", "Test Content");
+                new AdminNotificationRequest(AdminNotificationTargetType.LOGGED_OUT, List.of(), List.of(), List.of(), "Test Title", "Test Content", null);
 
         FcmToken fcmToken1 = new FcmToken(null, "sample_token_guest_1", "iphone");
         FcmToken fcmToken2 = new FcmToken(null, "sample_token_guest_2", "android");
@@ -169,7 +189,8 @@ class SendToMembersTest {
                         List.of(),
                         List.of(),
                         "Test Title",
-                        "Test Content"
+                        "Test Content",
+                        null
                 );
 
         FcmToken fcmToken1 = new FcmToken(69L, "sample_token_69", "iphone");
@@ -204,7 +225,8 @@ class SendToMembersTest {
                         List.of("201900069", "201900096", "209999999"),
                         List.of(),
                         "Test Title",
-                        "Test Content"
+                        "Test Content",
+                        null
                 );
 
         FcmToken fcmToken1 = new FcmToken(69L, "sample_token_69", "iphone");
@@ -238,7 +260,8 @@ class SendToMembersTest {
                         List.of(),
                         List.of(Department.COMPUTER_ENGINEERING),
                         "Test Title",
-                        "Test Content"
+                        "Test Content",
+                        null
                 );
 
         FcmToken fcmToken1 = new FcmToken(69L, "sample_token_69", "iphone");
@@ -282,7 +305,8 @@ class SendToMembersTest {
                 "Test Title",
                 "Test Content",
                 tokenAndMemberId,
-                List.of(69L, 77L)
+                List.of(69L, 77L),
+                null
         );
 
         BatchResponse batchResponse = mock(BatchResponse.class);
@@ -322,7 +346,8 @@ class SendToMembersTest {
                 "Test Title",
                 "Test Content",
                 tokenAndMemberId,
-                List.of(69L, 96L)
+                List.of(69L, 96L),
+                null
         );
 
         FirebaseMessagingException firebaseMessagingException = mock(FirebaseMessagingException.class);
@@ -352,7 +377,8 @@ class SendToMembersTest {
                 "Test Title",
                 "Test Content",
                 Map.of(),
-                List.of(69L, 96L)
+                List.of(69L, 96L),
+                null
         );
 
         when(fcmMessageRepository.findById(1L)).thenReturn(Optional.of(fcmMessage));

--- a/src/test/java/kr/inuappcenterportal/inuportal/member/FriendServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/member/FriendServiceTest.java
@@ -1,0 +1,141 @@
+package kr.inuappcenterportal.inuportal.member;
+
+import kr.inuappcenterportal.inuportal.domain.firebase.enums.FcmMessageType;
+import kr.inuappcenterportal.inuportal.domain.firebase.service.FcmAsyncService;
+import kr.inuappcenterportal.inuportal.domain.member.dto.FriendRequestDto;
+import kr.inuappcenterportal.inuportal.domain.member.enums.FriendStatus;
+import kr.inuappcenterportal.inuportal.domain.member.model.Friend;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.member.repository.BlockRepository;
+import kr.inuappcenterportal.inuportal.domain.member.repository.FriendRepository;
+import kr.inuappcenterportal.inuportal.domain.member.repository.MemberRepository;
+import kr.inuappcenterportal.inuportal.domain.member.service.FriendService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FriendServiceTest {
+
+    @Mock
+    private FriendRepository friendRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private BlockRepository blockRepository;
+
+    @Mock
+    private FcmAsyncService fcmAsyncService;
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Test
+    @DisplayName("친구 요청 시 FCM 알림에 correct path (/chat/list?category=친구)가 전달되어야 한다")
+    void requestFriend_sendsFcmNotificationWithCorrectPath() {
+        Member requester = Member.builder().studentId("202000001").roles(List.of("ROLE_USER")).build();
+        requester.updateNicknameAndFire("requester", 1L);
+        ReflectionTestUtils.setField(requester, "id", 1L);
+
+        Member receiver = Member.builder().studentId("202000002").roles(List.of("ROLE_USER")).build();
+        receiver.updateNicknameAndFire("receiver", 2L);
+        ReflectionTestUtils.setField(receiver, "id", 2L);
+
+        FriendRequestDto dto = new FriendRequestDto();
+        ReflectionTestUtils.setField(dto, "nickname", "receiver");
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(requester));
+        when(memberRepository.findByNickname("receiver")).thenReturn(Optional.of(receiver));
+        when(friendRepository.existsByRequesterAndReceiver(requester, receiver)).thenReturn(false);
+        when(friendRepository.existsByRequesterAndReceiver(receiver, requester)).thenReturn(false);
+        when(blockRepository.existsByBlockerAndBlocked(requester, receiver)).thenReturn(false);
+        when(blockRepository.existsByBlockerAndBlocked(receiver, requester)).thenReturn(false);
+        when(friendRepository.save(any(Friend.class))).thenAnswer(invocation -> {
+            Friend f = invocation.getArgument(0);
+            ReflectionTestUtils.setField(f, "id", 100L);
+            return f;
+        });
+
+        friendService.requestFriend(1L, dto);
+
+        verify(fcmAsyncService).sendAsyncTrackedNotification(
+                eq(List.of(2L)),
+                eq("친구 요청"),
+                eq("requester님이 친구 요청을 보냈습니다."),
+                eq(FcmMessageType.FRIEND),
+                eq(100L),
+                eq("/chat/list?category=친구")
+        );
+    }
+
+    @Test
+    @DisplayName("친구 수락 시 FCM 알림에 correct path (/chat/list?category=친구)가 전달되어야 한다")
+    void acceptFriend_sendsFcmNotificationWithCorrectPath() {
+        Member requester = Member.builder().studentId("202000001").roles(List.of("ROLE_USER")).build();
+        requester.updateNicknameAndFire("requester", 1L);
+        ReflectionTestUtils.setField(requester, "id", 1L);
+
+        Member receiver = Member.builder().studentId("202000002").roles(List.of("ROLE_USER")).build();
+        receiver.updateNicknameAndFire("receiver", 2L);
+        ReflectionTestUtils.setField(receiver, "id", 2L);
+
+        Friend friend = Friend.builder().requester(requester).receiver(receiver).status(FriendStatus.PENDING).build();
+        ReflectionTestUtils.setField(friend, "id", 100L);
+
+        when(friendRepository.findById(100L)).thenReturn(Optional.of(friend));
+
+        friendService.acceptFriend(2L, 100L);
+
+        verify(fcmAsyncService).sendAsyncTrackedNotification(
+                eq(List.of(1L)),
+                eq("친구 수락"),
+                eq("receiver님이 친구 요청을 수락했습니다."),
+                eq(FcmMessageType.FRIEND),
+                eq(100L),
+                eq("/chat/list?category=친구")
+        );
+    }
+
+    @Test
+    @DisplayName("친구 거절 시 FCM 알림에 correct path (/chat/list?category=친구)가 전달되어야 한다")
+    void deleteFriend_reject_sendsFcmNotificationWithCorrectPath() {
+        Member requester = Member.builder().studentId("202000001").roles(List.of("ROLE_USER")).build();
+        requester.updateNicknameAndFire("requester", 1L);
+        ReflectionTestUtils.setField(requester, "id", 1L);
+
+        Member receiver = Member.builder().studentId("202000002").roles(List.of("ROLE_USER")).build();
+        receiver.updateNicknameAndFire("receiver", 2L);
+        ReflectionTestUtils.setField(receiver, "id", 2L);
+
+        Friend friend = Friend.builder().requester(requester).receiver(receiver).status(FriendStatus.PENDING).build();
+        ReflectionTestUtils.setField(friend, "id", 100L);
+
+        when(friendRepository.findById(100L)).thenReturn(Optional.of(friend));
+
+        friendService.deleteFriend(2L, 100L);
+
+        verify(fcmAsyncService).sendAsyncTrackedNotification(
+                eq(List.of(1L)),
+                eq("친구 요청 결과"),
+                eq("친구 요청이 거절되었습니다."),
+                eq(FcmMessageType.FRIEND),
+                eq(100L),
+                eq("/chat/list?category=친구")
+        );
+        verify(friendRepository).delete(friend);
+    }
+}


### PR DESCRIPTION
## Summary
- FRIEND 타입 푸시 알림 이동 경로(path)를 /friend/list에서 actual friend request view /chat/list?category=친구로 수정
- eat/admin-push-path-payload 브랜치를 병합하여 관리자 수동 알림 발송(POST /api/tokens/admin)에도 path 페이로드 지원
- FriendServiceTest 단위 테스트 작성 및 SendToMembersTest 검증

Resolves #341