### PR TITLE
✨ feat : 건의사항 도메인 1차 개발 완료

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/controller/SuggestionController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/controller/SuggestionController.java
@@ -1,0 +1,83 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionAnswerRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionListResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.service.SuggestionService;
+import kr.inuappcenterportal.inuportal.global.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Suggestions", description = "건의사항 API")
+@RequestMapping("/api/suggestions")
+public class SuggestionController {
+    private final SuggestionService suggestionService;
+
+    @Operation(summary = "건의사항 등록", description = "바디에 건의 내용(content), 응원 메시지(cheerMessage, 선택), 문의 유형(category), 앱/기기 정보(appVersion, osType, osVersion, deviceModel, 선택)를 보내주세요. 결과 값은 등록된 건의사항의 id입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "건의사항 등록 성공", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+            , @ApiResponse(responseCode = "400", description = "잘못된 형식의 문의 유형을 요청했습니다.", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @PostMapping("")
+    public ResponseEntity<ResponseDto<Long>> saveSuggestion(@AuthenticationPrincipal Member member, @Valid @RequestBody SuggestionRequest suggestionRequest) {
+        return ResponseEntity.ok(ResponseDto.of(suggestionService.saveSuggestion(suggestionRequest, member), "건의사항 등록 성공"));
+    }
+
+    @Operation(summary = "건의사항 목록 가져오기", description = "헤더 Auth에 발급받은 토큰을, 페이지(공백일 시 1)를 보내주세요. 일반 사용자는 본인이 작성한 건의사항만, 관리자는 전체 건의사항을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "건의사항 목록 가져오기 성공", content = @Content(schema = @Schema(implementation = SuggestionListResponse.class)))
+    })
+    @GetMapping("")
+    public ResponseEntity<ResponseDto<SuggestionListResponse>> getSuggestionList(@AuthenticationPrincipal Member member, @RequestParam(required = false, defaultValue = "1") @Min(1) int page) {
+        return ResponseEntity.ok(ResponseDto.of(suggestionService.getSuggestionList(page, member), "건의사항 목록 가져오기 성공"));
+    }
+
+    @Operation(summary = "건의사항 상세 가져오기", description = "url 파라미터에 건의사항의 id를 보내주세요. 본인이 작성했거나 관리자만 조회할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "건의사항 상세 가져오기 성공", content = @Content(schema = @Schema(implementation = SuggestionResponse.class)))
+            , @ApiResponse(responseCode = "403", description = "이 건의사항에 대한 권한이 없습니다.", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+            , @ApiResponse(responseCode = "404", description = "존재하지 않는 건의사항입니다.", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @GetMapping("/{suggestionId}")
+    public ResponseEntity<ResponseDto<SuggestionResponse>> getSuggestion(@Parameter(name = "suggestionId", description = "건의사항의 id", in = ParameterIn.PATH) @PathVariable Long suggestionId, @AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(ResponseDto.of(suggestionService.getSuggestion(suggestionId, member), "건의사항 상세 가져오기 성공"));
+    }
+
+    @Operation(summary = "건의사항 삭제", description = "url 파라미터에 건의사항의 id를 보내주세요. 본인이 작성했거나 관리자만 삭제할 수 있으며, 처리 상태와 무관하게 항상 삭제 가능합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "건의사항 삭제 성공", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+            , @ApiResponse(responseCode = "403", description = "이 건의사항에 대한 권한이 없습니다.", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+            , @ApiResponse(responseCode = "404", description = "존재하지 않는 건의사항입니다.", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @DeleteMapping("/{suggestionId}")
+    public ResponseEntity<ResponseDto<Long>> deleteSuggestion(@Parameter(name = "suggestionId", description = "건의사항의 id", in = ParameterIn.PATH) @PathVariable Long suggestionId, @AuthenticationPrincipal Member member) {
+        return ResponseEntity.ok(ResponseDto.of(suggestionService.deleteSuggestion(suggestionId, member), "건의사항 삭제 성공"));
+    }
+
+    @Operation(summary = "건의사항 답변/상태변경 (관리자 전용)", description = "url 파라미터에 건의사항의 id, 바디에 처리 상태(status), 운영진 답변 내용(answerContent, 선택)을 보내주세요. 관리자 권한이 있는 사용자만 호출할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "건의사항 답변/상태변경 성공", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+            , @ApiResponse(responseCode = "400", description = "잘못된 형식의 건의사항 상태를 요청했습니다.", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+            , @ApiResponse(responseCode = "404", description = "존재하지 않는 건의사항입니다.", content = @Content(schema = @Schema(implementation = ResponseDto.class)))
+    })
+    @PatchMapping("/{suggestionId}/answer")
+    public ResponseEntity<ResponseDto<Long>> answerSuggestion(@Parameter(name = "suggestionId", description = "건의사항의 id", in = ParameterIn.PATH) @PathVariable Long suggestionId, @Valid @RequestBody SuggestionAnswerRequest suggestionAnswerRequest) {
+        return ResponseEntity.ok(ResponseDto.of(suggestionService.answerSuggestion(suggestionId, suggestionAnswerRequest), "건의사항 답변/상태변경 성공"));
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionAnswerRequest.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionAnswerRequest.java
@@ -1,0 +1,28 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "건의사항 답변/상태변경 요청 Dto (관리자 전용)")
+@Getter
+@NoArgsConstructor
+public class SuggestionAnswerRequest {
+
+    @Schema(description = "변경할 처리 상태", example = "COMPLETED", allowableValues = {"RECEIVED", "IN_REVIEW", "PLANNED", "COMPLETED", "ON_HOLD"})
+    @NotBlank
+    private String status;
+
+    @Schema(description = "운영진 답변 내용 (답변 없이 상태만 변경할 경우 생략 가능)", example = "다음 업데이트에 반영 예정입니다.")
+    @Size(max = 2000)
+    private String answerContent;
+
+    @Builder
+    public SuggestionAnswerRequest(String status, String answerContent) {
+        this.status = status;
+        this.answerContent = answerContent;
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionListResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionListResponse.java
@@ -1,0 +1,41 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.inuappcenterportal.inuportal.domain.suggestion.model.Suggestion;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Schema(description = "건의사항 리스트 응답 Dto")
+@Getter
+@NoArgsConstructor
+public class SuggestionListResponse {
+
+    @Schema(description = "총 페이지 수")
+    private Integer pages;
+
+    @Schema(description = "총 건의사항 수")
+    private Long total;
+
+    @Schema(description = "건의사항 리스트")
+    private List<SuggestionResponse> suggestions;
+
+    @Builder
+    private SuggestionListResponse(int pages, long total, List<SuggestionResponse> suggestions) {
+        this.pages = pages;
+        this.total = total;
+        this.suggestions = suggestions;
+    }
+
+    public static SuggestionListResponse of(Page<Suggestion> suggestionPage) {
+        return SuggestionListResponse.builder()
+                .pages(suggestionPage.getTotalPages())
+                .total(suggestionPage.getTotalElements())
+                .suggestions(suggestionPage.getContent().stream().map(SuggestionResponse::of).collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionRequest.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionRequest.java
@@ -1,0 +1,51 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "건의사항 등록 Dto")
+@Getter
+@NoArgsConstructor
+public class SuggestionRequest {
+
+    @Schema(description = "건의 내용", example = "특정 게시판에서 이미지 업로드가 안 돼요.")
+    @NotBlank
+    @Size(max = 2000)
+    private String content;
+
+    @Schema(description = "개발자 응원 메시지", example = "항상 잘 쓰고 있어요, 감사합니다!")
+    @Size(max = 1000)
+    private String cheerMessage;
+
+    @Schema(description = "문의 유형", example = "BUG", allowableValues = {"BUG", "FEATURE_REQUEST", "ETC"})
+    @NotBlank
+    private String category;
+
+    @Schema(description = "앱 버전 (클라이언트가 자동으로 채워서 전송)", example = "1.4.2")
+    private String appVersion;
+
+    @Schema(description = "OS 타입 (클라이언트가 자동으로 채워서 전송)", example = "IOS")
+    private String osType;
+
+    @Schema(description = "OS 버전 (클라이언트가 자동으로 채워서 전송)", example = "17.4")
+    private String osVersion;
+
+    @Schema(description = "기기 모델명 (클라이언트가 자동으로 채워서 전송)", example = "iPhone15,3")
+    private String deviceModel;
+
+    @Builder
+    public SuggestionRequest(String content, String cheerMessage, String category, String appVersion,
+                              String osType, String osVersion, String deviceModel) {
+        this.content = content;
+        this.cheerMessage = cheerMessage;
+        this.category = category;
+        this.appVersion = appVersion;
+        this.osType = osType;
+        this.osVersion = osVersion;
+        this.deviceModel = deviceModel;
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionResponse.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/dto/SuggestionResponse.java
@@ -1,0 +1,90 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import kr.inuappcenterportal.inuportal.domain.suggestion.model.Suggestion;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.format.DateTimeFormatter;
+
+@Schema(description = "건의사항 상세 응답 Dto")
+@Getter
+@NoArgsConstructor
+public class SuggestionResponse {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss");
+
+    @Schema(description = "건의사항의 데이터베이스 id 값")
+    private Long id;
+    @Schema(description = "건의 내용")
+    private String content;
+    @Schema(description = "개발자 응원 메시지")
+    private String cheerMessage;
+    @Schema(description = "문의 유형")
+    private String category;
+    @Schema(description = "앱 버전")
+    private String appVersion;
+    @Schema(description = "OS 타입")
+    private String osType;
+    @Schema(description = "OS 버전")
+    private String osVersion;
+    @Schema(description = "기기 모델명")
+    private String deviceModel;
+    @Schema(description = "처리 상태")
+    private String status;
+    @Schema(description = "운영진 답변 내용")
+    private String answerContent;
+    @Schema(description = "답변 일시")
+    private String answerDate;
+    @Schema(description = "작성일시")
+    private String createDate;
+    @Schema(description = "수정일시 (답변 포함)")
+    private String modifiedDate;
+    @Schema(description = "작성자 id")
+    private Long memberId;
+    @Schema(description = "작성자 닉네임")
+    private String memberNickname;
+
+    @Builder
+    private SuggestionResponse(Long id, String content, String cheerMessage, String category, String appVersion,
+                                   String osType, String osVersion, String deviceModel, String status,
+                                   String answerContent, String answerDate, String createDate, String modifiedDate,
+                                   Long memberId, String memberNickname) {
+        this.id = id;
+        this.content = content;
+        this.cheerMessage = cheerMessage;
+        this.category = category;
+        this.appVersion = appVersion;
+        this.osType = osType;
+        this.osVersion = osVersion;
+        this.deviceModel = deviceModel;
+        this.status = status;
+        this.answerContent = answerContent;
+        this.answerDate = answerDate;
+        this.createDate = createDate;
+        this.modifiedDate = modifiedDate;
+        this.memberId = memberId;
+        this.memberNickname = memberNickname;
+    }
+
+    public static SuggestionResponse of(Suggestion suggestion) {
+        return SuggestionResponse.builder()
+                .id(suggestion.getId())
+                .content(suggestion.getContent())
+                .cheerMessage(suggestion.getCheerMessage())
+                .category(suggestion.getCategory().name())
+                .appVersion(suggestion.getAppVersion())
+                .osType(suggestion.getOsType())
+                .osVersion(suggestion.getOsVersion())
+                .deviceModel(suggestion.getDeviceModel())
+                .status(suggestion.getStatus().name())
+                .answerContent(suggestion.getAnswerContent())
+                .answerDate(suggestion.getAnswerDate() == null ? null : suggestion.getAnswerDate().format(DATE_TIME_FORMATTER))
+                .createDate(suggestion.getCreateDate().format(DATE_TIME_FORMATTER))
+                .modifiedDate(suggestion.getModifiedDate().format(DATE_TIME_FORMATTER))
+                .memberId(suggestion.getMember().getId())
+                .memberNickname(suggestion.getMember().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/enums/SuggestionCategory.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/enums/SuggestionCategory.java
@@ -1,0 +1,16 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.enums;
+
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+
+public enum SuggestionCategory {
+    BUG, FEATURE_REQUEST, ETC;
+
+    public static SuggestionCategory from(String name) {
+        try {
+            return SuggestionCategory.valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new MyException(MyErrorCode.WRONG_SUGGESTION_CATEGORY);
+        }
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/enums/SuggestionStatus.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/enums/SuggestionStatus.java
@@ -1,0 +1,5 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.enums;
+
+public enum SuggestionStatus {
+    RECEIVED, IN_REVIEW, PLANNED, COMPLETED, ON_HOLD
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/model/Suggestion.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/model/Suggestion.java
@@ -1,0 +1,100 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.model;
+
+import jakarta.persistence.*;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.suggestion.enums.SuggestionCategory;
+import kr.inuappcenterportal.inuportal.domain.suggestion.enums.SuggestionStatus;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import kr.inuappcenterportal.inuportal.global.model.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "suggestion")
+public class Suggestion extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 2000)
+    private String content;
+
+    @Column(name = "cheer_message", length = 1000)
+    private String cheerMessage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SuggestionCategory category;
+
+    @Column(name = "app_version")
+    private String appVersion;
+
+    @Column(name = "os_type", length = 10)
+    private String osType;
+
+    @Column(name = "os_version")
+    private String osVersion;
+
+    @Column(name = "device_model")
+    private String deviceModel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SuggestionStatus status;
+
+    @Column(name = "answer_content", length = 2000)
+    private String answerContent;
+
+    @Column(name = "answer_date")
+    private LocalDateTime answerDate;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+    @Builder
+    public Suggestion(String content, String cheerMessage, Member member, SuggestionCategory category,
+                       String appVersion, String osType, String osVersion, String deviceModel) {
+        this.content = content;
+        this.cheerMessage = cheerMessage;
+        this.member = member;
+        this.category = category;
+        this.appVersion = appVersion;
+        this.osType = osType;
+        this.osVersion = osVersion;
+        this.deviceModel = deviceModel;
+        this.status = SuggestionStatus.RECEIVED;
+        this.isDeleted = false;
+    }
+
+    public void changeStatus(String status) {
+        try {
+            this.status = SuggestionStatus.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            throw new MyException(MyErrorCode.WRONG_SUGGESTION_STATUS);
+        }
+    }
+
+    public void registerAnswer(String answerContent, String status) {
+        changeStatus(status);
+        if (answerContent != null) {
+            this.answerContent = answerContent;
+            this.answerDate = LocalDateTime.now();
+        }
+    }
+
+    public void deleteSuggestion() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/repository/SuggestionRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/repository/SuggestionRepository.java
@@ -1,0 +1,24 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.repository;
+
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.suggestion.model.Suggestion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface SuggestionRepository extends JpaRepository<Suggestion, Long> {
+
+    Optional<Suggestion> findByIdAndIsDeletedFalse(Long id);
+
+    @Query("SELECT s FROM Suggestion s JOIN FETCH s.member WHERE s.id = :id AND s.isDeleted = false")
+    Optional<Suggestion> findByIdWithMember(@Param("id") Long id);
+
+    @Query("SELECT s FROM Suggestion s JOIN FETCH s.member WHERE s.isDeleted = false")
+    Page<Suggestion> findAllWithMember(Pageable pageable);
+
+    Page<Suggestion> findAllByMemberAndIsDeletedFalse(Member member, Pageable pageable);
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/service/SuggestionService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/suggestion/service/SuggestionService.java
@@ -1,0 +1,81 @@
+package kr.inuappcenterportal.inuportal.domain.suggestion.service;
+
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionAnswerRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionListResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.enums.SuggestionCategory;
+import kr.inuappcenterportal.inuportal.domain.suggestion.model.Suggestion;
+import kr.inuappcenterportal.inuportal.domain.suggestion.repository.SuggestionRepository;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SuggestionService {
+
+    private final SuggestionRepository suggestionRepository;
+
+    @Transactional
+    public Long saveSuggestion(SuggestionRequest suggestionRequest, Member member) {
+        Suggestion suggestion = Suggestion.builder()
+                .content(suggestionRequest.getContent())
+                .cheerMessage(suggestionRequest.getCheerMessage())
+                .member(member)
+                .category(SuggestionCategory.from(suggestionRequest.getCategory()))
+                .appVersion(suggestionRequest.getAppVersion())
+                .osType(suggestionRequest.getOsType())
+                .osVersion(suggestionRequest.getOsVersion())
+                .deviceModel(suggestionRequest.getDeviceModel())
+                .build();
+        return suggestionRepository.save(suggestion).getId();
+    }
+
+    public SuggestionResponse getSuggestion(Long suggestionId, Member member) {
+        Suggestion suggestion = suggestionRepository.findByIdWithMember(suggestionId)
+                .orElseThrow(() -> new MyException(MyErrorCode.SUGGESTION_NOT_FOUND));
+        if (!suggestion.getMember().getId().equals(member.getId()) && !member.getRoles().contains("ROLE_ADMIN")) {
+            throw new MyException(MyErrorCode.HAS_NOT_SUGGESTION_AUTHORIZATION);
+        }
+        return SuggestionResponse.of(suggestion);
+    }
+
+    public SuggestionListResponse getSuggestionList(int page, Member member) {
+        Pageable pageable = PageRequest.of(page > 0 ? --page : page, 8);
+        Page<Suggestion> suggestions = member.getRoles().contains("ROLE_ADMIN")
+                ? suggestionRepository.findAllWithMember(pageable)
+                : suggestionRepository.findAllByMemberAndIsDeletedFalse(member, pageable);
+        return SuggestionListResponse.of(suggestions);
+    }
+
+    @Transactional
+    public Long deleteSuggestion(Long suggestionId, Member member) {
+        Suggestion suggestion = validHasAuthorizationSuggestion(suggestionId, member);
+        suggestion.deleteSuggestion();
+        return suggestionId;
+    }
+
+    @Transactional
+    public Long answerSuggestion(Long suggestionId, SuggestionAnswerRequest suggestionAnswerRequest) {
+        Suggestion suggestion = suggestionRepository.findByIdAndIsDeletedFalse(suggestionId)
+                .orElseThrow(() -> new MyException(MyErrorCode.SUGGESTION_NOT_FOUND));
+        suggestion.registerAnswer(suggestionAnswerRequest.getAnswerContent(), suggestionAnswerRequest.getStatus());
+        return suggestionId;
+    }
+
+    private Suggestion validHasAuthorizationSuggestion(Long suggestionId, Member member) {
+        Suggestion suggestion = suggestionRepository.findByIdAndIsDeletedFalse(suggestionId)
+                .orElseThrow(() -> new MyException(MyErrorCode.SUGGESTION_NOT_FOUND));
+        if (!suggestion.getMember().getId().equals(member.getId()) && !member.getRoles().contains("ROLE_ADMIN")) {
+            throw new MyException(MyErrorCode.HAS_NOT_SUGGESTION_AUTHORIZATION);
+        }
+        return suggestion;
+    }
+}

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/config/SecurityConfig.java
@@ -53,11 +53,12 @@ public class SecurityConfig {
                         // ADMIN 권한 전용 설정
                         .requestMatchers(HttpMethod.POST, "/api/directory/sync", "/api/directory/sources/sync", "/api/directory/college-office-contacts/sync", "/api/semesters/sync", "/api/courses/sync", "/api/course-offerings/sync").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/logs/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/suggestions/*/answer").hasRole("ADMIN")
                         .requestMatchers("/api/members/all", "/api/reports", "/api/images", "/api/images/**", "/api/categories", "/api/councilNotices", "/api/councilNotices/**", "/api/books/**", "/api/items/**", "/api/lost/**", "/api/clubs/**", "/api/tokens/admin/**", "/api/admin/feature-flags/**").hasRole("ADMIN")
 
                         // USER 또는 ADMIN 권한 설정
                         .requestMatchers(HttpMethod.POST, "/api/reports/**", "/api/portal/**").hasAnyRole("USER", "ADMIN")
-                        .requestMatchers("/api/chat-rooms/**", "/api/members/**", "/api/members", "/api/friends", "/api/friends/**", "/api/tokens", "/api/posts/**", "/api/posts", "/api/fires/**", "/api/petitions", "/api/petitions/**", "/api/replies/**", "/api/reservations/**", "/api/folders/**", "/api/folders", "/api/search/**", "/api/keywords/**").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers("/api/chat-rooms/**", "/api/members/**", "/api/members", "/api/friends", "/api/friends/**", "/api/tokens", "/api/posts/**", "/api/posts", "/api/fires/**", "/api/petitions", "/api/petitions/**", "/api/replies/**", "/api/reservations/**", "/api/folders/**", "/api/folders", "/api/search/**", "/api/keywords/**", "/api/suggestions", "/api/suggestions/**").hasAnyRole("USER", "ADMIN")
 
                         // 추가 인증 필요 설정
                         .requestMatchers(HttpMethod.POST, "/api/chat/messages").authenticated()

--- a/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/global/exception/ex/MyErrorCode.java
@@ -112,6 +112,11 @@ public enum MyErrorCode {
     GRADE_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 성적입니다."),
     HAS_NOT_GRADE_RECORD_AUTHORIZATION(HttpStatus.FORBIDDEN, "해당 성적에 접근할 수 없습니다."),
 
+    SUGGESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 건의사항입니다."),
+    HAS_NOT_SUGGESTION_AUTHORIZATION(HttpStatus.FORBIDDEN, "이 건의사항에 대한 권한이 없습니다."),
+    WRONG_SUGGESTION_STATUS(HttpStatus.BAD_REQUEST, "잘못된 형식의 건의사항 상태를 요청했습니다."),
+    WRONG_SUGGESTION_CATEGORY(HttpStatus.BAD_REQUEST, "잘못된 형식의 문의 유형을 요청했습니다."),
+
 
     // Chat 관련 에러 코드 추가
     NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),

--- a/src/test/java/kr/inuappcenterportal/inuportal/suggestion/SuggestionControllerTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/suggestion/SuggestionControllerTest.java
@@ -1,0 +1,273 @@
+package kr.inuappcenterportal.inuportal.suggestion;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.suggestion.controller.SuggestionController;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionAnswerRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionListResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.enums.SuggestionCategory;
+import kr.inuappcenterportal.inuportal.domain.suggestion.model.Suggestion;
+import kr.inuappcenterportal.inuportal.domain.suggestion.service.SuggestionService;
+import kr.inuappcenterportal.inuportal.global.config.CustomResourceResolver;
+import kr.inuappcenterportal.inuportal.global.config.SecurityConfig;
+import kr.inuappcenterportal.inuportal.global.config.TokenProvider;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SuggestionController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@Import(SecurityConfig.class)
+public class SuggestionControllerTest {
+    @MockBean
+    private CustomResourceResolver customResourceResolver;
+    @Autowired
+    MockMvc mockMvc;
+    ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    SuggestionController suggestionController;
+    @MockBean
+    SuggestionService suggestionService;
+    @MockBean
+    TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("건의사항 등록 테스트")
+    public void saveSuggestion() throws Exception {
+        Member authMember = mock(Member.class);
+        when(authMember.getId()).thenReturn(1L);
+        String token = "testToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        SuggestionRequest suggestionRequest = SuggestionRequest.builder()
+                .content("이미지 업로드가 안 돼요")
+                .category("BUG")
+                .build();
+        when(suggestionService.saveSuggestion(any(SuggestionRequest.class), any(Member.class))).thenReturn(1L);
+
+        String body = objectMapper.writeValueAsString(suggestionRequest);
+        mockMvc.perform(post("/api/suggestions").content(body).with(csrf()).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("건의사항 등록 성공"))
+                .andExpect(jsonPath("$.data").value(1L))
+                .andDo(print());
+        verify(suggestionService).saveSuggestion(any(SuggestionRequest.class), any(Member.class));
+    }
+
+    @Test
+    @DisplayName("건의사항 목록조회 테스트")
+    public void getSuggestionList() throws Exception {
+        Member authMember = mock(Member.class);
+        when(authMember.getId()).thenReturn(1L);
+        String token = "testToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+        when(writer.getNickname()).thenReturn("nickname");
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+        ReflectionTestUtils.setField(suggestion, "createDate", LocalDateTime.now());
+        ReflectionTestUtils.setField(suggestion, "modifiedDate", LocalDateTime.now());
+
+        Pageable pageable = PageRequest.of(0, 8);
+        Page<Suggestion> mockPage = new PageImpl<>(List.of(suggestion), pageable, 1);
+        SuggestionListResponse suggestionListResponse = SuggestionListResponse.of(mockPage);
+
+        when(suggestionService.getSuggestionList(1, authMember)).thenReturn(suggestionListResponse);
+
+        mockMvc.perform(get("/api/suggestions").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("건의사항 목록 가져오기 성공"))
+                .andExpect(jsonPath("$.data.total").value(1))
+                .andExpect(jsonPath("$.data.pages").value(1))
+                .andDo(print());
+        verify(suggestionService).getSuggestionList(1, authMember);
+    }
+
+    @Test
+    @DisplayName("건의사항 상세조회 성공 테스트")
+    public void getSuggestion_success() throws Exception {
+        Member authMember = mock(Member.class);
+        String token = "testToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+        when(writer.getNickname()).thenReturn("nickname");
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+        ReflectionTestUtils.setField(suggestion, "createDate", LocalDateTime.now());
+        ReflectionTestUtils.setField(suggestion, "modifiedDate", LocalDateTime.now());
+        SuggestionResponse suggestionResponse = SuggestionResponse.of(suggestion);
+
+        when(suggestionService.getSuggestion(1L, authMember)).thenReturn(suggestionResponse);
+
+        mockMvc.perform(get("/api/suggestions/1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("건의사항 상세 가져오기 성공"))
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.memberNickname").value("nickname"))
+                .andDo(print());
+        verify(suggestionService).getSuggestion(1L, authMember);
+    }
+
+    @Test
+    @DisplayName("건의사항 상세조회 실패 테스트 (권한 없음)")
+    public void getSuggestion_fail_authorization() throws Exception {
+        Member authMember = mock(Member.class);
+        String token = "testToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        when(suggestionService.getSuggestion(1L, authMember)).thenThrow(new MyException(MyErrorCode.HAS_NOT_SUGGESTION_AUTHORIZATION));
+
+        mockMvc.perform(get("/api/suggestions/1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.msg").value(MyErrorCode.HAS_NOT_SUGGESTION_AUTHORIZATION.getMessage()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("건의사항 상세조회 실패 테스트 (존재하지 않음)")
+    public void getSuggestion_fail_notFound() throws Exception {
+        Member authMember = mock(Member.class);
+        String token = "testToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        when(suggestionService.getSuggestion(1L, authMember)).thenThrow(new MyException(MyErrorCode.SUGGESTION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/suggestions/1").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.msg").value(MyErrorCode.SUGGESTION_NOT_FOUND.getMessage()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("건의사항 삭제 테스트")
+    public void deleteSuggestion() throws Exception {
+        Member authMember = mock(Member.class);
+        String token = "testToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        when(suggestionService.deleteSuggestion(1L, authMember)).thenReturn(1L);
+
+        mockMvc.perform(delete("/api/suggestions/1").with(csrf()).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("건의사항 삭제 성공"))
+                .andExpect(jsonPath("$.data").value(1L))
+                .andDo(print());
+        verify(suggestionService).deleteSuggestion(1L, authMember);
+    }
+
+    @Test
+    @DisplayName("건의사항 답변등록 테스트 (관리자)")
+    public void answerSuggestion_admin() throws Exception {
+        Member authMember = mock(Member.class);
+        String token = "adminToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
+
+        SuggestionAnswerRequest suggestionAnswerRequest = SuggestionAnswerRequest.builder()
+                .status("COMPLETED")
+                .answerContent("다음 업데이트에 반영했습니다.")
+                .build();
+        when(suggestionService.answerSuggestion(eq(1L), any(SuggestionAnswerRequest.class))).thenReturn(1L);
+
+        String body = objectMapper.writeValueAsString(suggestionAnswerRequest);
+        mockMvc.perform(patch("/api/suggestions/1/answer").content(body).with(csrf()).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.msg").value("건의사항 답변/상태변경 성공"))
+                .andExpect(jsonPath("$.data").value(1L))
+                .andDo(print());
+        verify(suggestionService).answerSuggestion(eq(1L), any(SuggestionAnswerRequest.class));
+    }
+
+    @Test
+    @DisplayName("건의사항 답변등록 실패 테스트 (USER 권한 - SecurityConfig 차단)")
+    public void answerSuggestion_fail_forbiddenForUser() throws Exception {
+        Member authMember = mock(Member.class);
+        String token = "userToken";
+        when(tokenProvider.resolveToken(any(HttpServletRequest.class))).thenReturn(token);
+        when(tokenProvider.validateToken(token)).thenReturn(true);
+        when(tokenProvider.getAuthentication(token))
+                .thenReturn(new UsernamePasswordAuthenticationToken(authMember, "", List.of(new SimpleGrantedAuthority("ROLE_USER"))));
+
+        SuggestionAnswerRequest suggestionAnswerRequest = SuggestionAnswerRequest.builder()
+                .status("COMPLETED")
+                .answerContent("다음 업데이트에 반영했습니다.")
+                .build();
+
+        String body = objectMapper.writeValueAsString(suggestionAnswerRequest);
+        mockMvc.perform(patch("/api/suggestions/1/answer").content(body).with(csrf()).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.msg").value("접근 권한이 없는 사용자입니다."))
+                .andDo(print());
+        verify(suggestionService, never()).answerSuggestion(any(), any());
+    }
+}

--- a/src/test/java/kr/inuappcenterportal/inuportal/suggestion/SuggestionServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/suggestion/SuggestionServiceTest.java
@@ -1,0 +1,317 @@
+package kr.inuappcenterportal.inuportal.suggestion;
+
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionAnswerRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionListResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionRequest;
+import kr.inuappcenterportal.inuportal.domain.suggestion.dto.SuggestionResponse;
+import kr.inuappcenterportal.inuportal.domain.suggestion.enums.SuggestionCategory;
+import kr.inuappcenterportal.inuportal.domain.suggestion.enums.SuggestionStatus;
+import kr.inuappcenterportal.inuportal.domain.suggestion.model.Suggestion;
+import kr.inuappcenterportal.inuportal.domain.suggestion.repository.SuggestionRepository;
+import kr.inuappcenterportal.inuportal.domain.suggestion.service.SuggestionService;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class SuggestionServiceTest {
+
+    @InjectMocks
+    private SuggestionService suggestionService;
+
+    @Mock
+    private SuggestionRepository suggestionRepository;
+
+    @Test
+    @DisplayName("건의사항 등록 테스트")
+    public void saveSuggestion() {
+        Member member = mock(Member.class);
+
+        SuggestionRequest suggestionRequest = SuggestionRequest.builder()
+                .content("이미지 업로드가 안 돼요")
+                .cheerMessage("항상 감사합니다")
+                .category("BUG")
+                .appVersion("1.0.0")
+                .osType("IOS")
+                .osVersion("17.4")
+                .deviceModel("iPhone15,3")
+                .build();
+
+        Suggestion suggestion = Suggestion.builder().build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+
+        when(suggestionRepository.save(any(Suggestion.class))).thenReturn(suggestion);
+
+        Long suggestionId = suggestionService.saveSuggestion(suggestionRequest, member);
+
+        Assertions.assertThat(suggestionId).isEqualTo(1L);
+        verify(suggestionRepository).save(any(Suggestion.class));
+    }
+
+    @Test
+    @DisplayName("건의사항 상세조회 성공 테스트 (작성자 본인)")
+    public void getSuggestion_success() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(1L);
+        when(member.getNickname()).thenReturn("nickname");
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(member)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+        ReflectionTestUtils.setField(suggestion, "createDate", LocalDateTime.now());
+        ReflectionTestUtils.setField(suggestion, "modifiedDate", LocalDateTime.now());
+
+        when(suggestionRepository.findByIdWithMember(1L)).thenReturn(Optional.of(suggestion));
+
+        SuggestionResponse response = suggestionService.getSuggestion(1L, member);
+
+        Assertions.assertThat(response.getId()).isEqualTo(1L);
+        Assertions.assertThat(response.getMemberId()).isEqualTo(1L);
+        Assertions.assertThat(response.getMemberNickname()).isEqualTo("nickname");
+    }
+
+    @Test
+    @DisplayName("건의사항 상세조회 실패 테스트 (작성자도 관리자도 아님)")
+    public void getSuggestion_fail_authorization() {
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+
+        Member other = mock(Member.class);
+        when(other.getId()).thenReturn(2L);
+        when(other.getRoles()).thenReturn(List.of("ROLE_USER"));
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+
+        when(suggestionRepository.findByIdWithMember(1L)).thenReturn(Optional.of(suggestion));
+
+        Assertions.assertThatThrownBy(() -> suggestionService.getSuggestion(1L, other))
+                .isInstanceOf(MyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MyErrorCode.HAS_NOT_SUGGESTION_AUTHORIZATION);
+    }
+
+    @Test
+    @DisplayName("건의사항 상세조회 실패 테스트 (존재하지 않음)")
+    public void getSuggestion_fail_notFound() {
+        Member member = mock(Member.class);
+
+        when(suggestionRepository.findByIdWithMember(1L)).thenReturn(Optional.empty());
+
+        Assertions.assertThatThrownBy(() -> suggestionService.getSuggestion(1L, member))
+                .isInstanceOf(MyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MyErrorCode.SUGGESTION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("건의사항 목록조회 테스트 (관리자 - 전체조회)")
+    public void getSuggestionList_admin() {
+        Member admin = mock(Member.class);
+        when(admin.getRoles()).thenReturn(List.of("ROLE_ADMIN"));
+
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+        when(writer.getNickname()).thenReturn("nickname");
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+        ReflectionTestUtils.setField(suggestion, "createDate", LocalDateTime.now());
+        ReflectionTestUtils.setField(suggestion, "modifiedDate", LocalDateTime.now());
+
+        Pageable pageable = PageRequest.of(0, 8);
+        Page<Suggestion> mockPage = new PageImpl<>(List.of(suggestion), pageable, 1);
+
+        when(suggestionRepository.findAllWithMember(any(Pageable.class))).thenReturn(mockPage);
+
+        SuggestionListResponse response = suggestionService.getSuggestionList(1, admin);
+
+        Assertions.assertThat(response.getTotal()).isEqualTo(1);
+        Assertions.assertThat(response.getSuggestions()).hasSize(1);
+        verify(suggestionRepository).findAllWithMember(pageable);
+    }
+
+    @Test
+    @DisplayName("건의사항 목록조회 테스트 (일반 사용자 - 본인 글만)")
+    public void getSuggestionList_user() {
+        Member member = mock(Member.class);
+        when(member.getRoles()).thenReturn(List.of("ROLE_USER"));
+        when(member.getId()).thenReturn(1L);
+        when(member.getNickname()).thenReturn("nickname");
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(member)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+        ReflectionTestUtils.setField(suggestion, "createDate", LocalDateTime.now());
+        ReflectionTestUtils.setField(suggestion, "modifiedDate", LocalDateTime.now());
+
+        Pageable pageable = PageRequest.of(0, 8);
+        Page<Suggestion> mockPage = new PageImpl<>(List.of(suggestion), pageable, 1);
+
+        when(suggestionRepository.findAllByMemberAndIsDeletedFalse(any(Member.class), any(Pageable.class))).thenReturn(mockPage);
+
+        SuggestionListResponse response = suggestionService.getSuggestionList(1, member);
+
+        Assertions.assertThat(response.getTotal()).isEqualTo(1);
+        Assertions.assertThat(response.getSuggestions()).hasSize(1);
+        verify(suggestionRepository).findAllByMemberAndIsDeletedFalse(member, pageable);
+    }
+
+    @Test
+    @DisplayName("건의사항 삭제 성공 테스트 (작성자 본인)")
+    public void deleteSuggestion_success() {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(1L);
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(member)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+
+        when(suggestionRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(suggestion));
+
+        Long deletedId = suggestionService.deleteSuggestion(1L, member);
+
+        Assertions.assertThat(deletedId).isEqualTo(1L);
+        Assertions.assertThat(suggestion.getIsDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("건의사항 삭제 성공 테스트 (관리자가 타인 글 삭제)")
+    public void deleteSuggestion_success_admin() {
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+
+        Member admin = mock(Member.class);
+        when(admin.getId()).thenReturn(2L);
+        when(admin.getRoles()).thenReturn(List.of("ROLE_ADMIN"));
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+
+        when(suggestionRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(suggestion));
+
+        Long deletedId = suggestionService.deleteSuggestion(1L, admin);
+
+        Assertions.assertThat(deletedId).isEqualTo(1L);
+        Assertions.assertThat(suggestion.getIsDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("건의사항 삭제 실패 테스트 (작성자도 관리자도 아님)")
+    public void deleteSuggestion_fail_authorization() {
+        Member writer = mock(Member.class);
+        when(writer.getId()).thenReturn(1L);
+
+        Member other = mock(Member.class);
+        when(other.getId()).thenReturn(2L);
+        when(other.getRoles()).thenReturn(List.of("ROLE_USER"));
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+
+        when(suggestionRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(suggestion));
+
+        Assertions.assertThatThrownBy(() -> suggestionService.deleteSuggestion(1L, other))
+                .isInstanceOf(MyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MyErrorCode.HAS_NOT_SUGGESTION_AUTHORIZATION);
+
+        Assertions.assertThat(suggestion.getIsDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("건의사항 답변등록 성공 테스트")
+    public void answerSuggestion_success() {
+        Member writer = mock(Member.class);
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+
+        SuggestionAnswerRequest suggestionAnswerRequest = SuggestionAnswerRequest.builder()
+                .status("COMPLETED")
+                .answerContent("다음 업데이트에 반영했습니다.")
+                .build();
+
+        when(suggestionRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(suggestion));
+
+        Long answeredId = suggestionService.answerSuggestion(1L, suggestionAnswerRequest);
+
+        Assertions.assertThat(answeredId).isEqualTo(1L);
+        Assertions.assertThat(suggestion.getStatus()).isEqualTo(SuggestionStatus.COMPLETED);
+        Assertions.assertThat(suggestion.getAnswerContent()).isEqualTo("다음 업데이트에 반영했습니다.");
+        Assertions.assertThat(suggestion.getAnswerDate()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("건의사항 답변등록 실패 테스트 (잘못된 상태값)")
+    public void answerSuggestion_fail_wrongStatus() {
+        Member writer = mock(Member.class);
+
+        Suggestion suggestion = Suggestion.builder()
+                .content("내용")
+                .category(SuggestionCategory.BUG)
+                .member(writer)
+                .build();
+        ReflectionTestUtils.setField(suggestion, "id", 1L);
+
+        SuggestionAnswerRequest suggestionAnswerRequest = SuggestionAnswerRequest.builder()
+                .status("NOT_A_REAL_STATUS")
+                .answerContent("다음 업데이트에 반영했습니다.")
+                .build();
+
+        when(suggestionRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(suggestion));
+
+        Assertions.assertThatThrownBy(() -> suggestionService.answerSuggestion(1L, suggestionAnswerRequest))
+                .isInstanceOf(MyException.class)
+                .hasFieldOrPropertyWithValue("errorCode", MyErrorCode.WRONG_SUGGESTION_STATUS);
+
+        Assertions.assertThat(suggestion.getAnswerContent()).isNull();
+    }
+}


### PR DESCRIPTION
## 📎 관련 이슈

- closed #356 


<h1>건의사항(Suggestion) API 구현 요약</h1>
<hr>
<h2>주요 설계 결정</h2>

항목 | 결정 | 이유
-- | -- | --
작성자 참조 | @ManyToOne Member | 목록/상세에서 작성자 닉네임 조인 조회가 필요해서
운영진 답변 | 별도 엔티티 없이 Suggestion에 answerContent/answerDate 필드로 직접 포함 | 건의 1건당 답변은 1개(덮어쓰기)로 충분
처리 상태 | enum 5종: RECEIVED, IN_REVIEW, PLANNED, COMPLETED, ON_HOLD |  
문의 유형 | enum 3종: BUG, FEATURE_REQUEST, ETC | 처음엔 UI_UX도 있었으나, 사용자 입장에선 결국 “불편사항”이라 BUG로 흡수
앱/기기 정보 | appVersion, osType, osVersion, deviceModel — 전부 자유 문자열 | 클라이언트 앱이 기기에서 읽어 자동으로 채워 보내는 진단용 필드.
삭제 | isDeleted soft delete, 처리 상태와 무관하게 항상 삭제 가능 (작성자 본인 또는 관리자) | 별도 제약 없이 단순하게
목록 조회 범위 | 일반 사용자는 본인 글만, 관리자는 전체 조회 | 건의사항은 공개 게시판이 아닌 개인 피드백 성격

<hr>
<h2>향후 확장 여지</h2>
<p>이미지 첨부는 이번 범위에 포함하지 않았습니다.</p>
<!-- notionvc: 2fa2f70c-c04d-49d9-8ff7-fcff445794d1 -->