### PR TITLE
feat: 게시글/댓글 작성자를 postId/replyId만으로 차단 (익명 포함) (#368)

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/controller/ChatBlockController.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/controller/ChatBlockController.java
@@ -31,6 +31,27 @@ public class ChatBlockController {
         return ResponseEntity.ok(ResponseDto.of(null));
     }
 
+    @Operation(summary = "게시글 작성자 차단",
+            description = "PostResponseDto/PostListResponseDto는 memberId를 내려주지 않아(익명 글 재식별 방지) " +
+                    "클라이언트가 대상 memberId를 알 수 없다. postId만으로 차단한다.")
+    @SecurityRequirement(name = "Auth")
+    @PostMapping("/by-post/{postId}")
+    public ResponseEntity<ResponseDto<Void>> blockUserByPostId(@PathVariable Long postId, @AuthenticationPrincipal UserDetails userDetails) {
+        Long memberId = Long.parseLong(userDetails.getUsername());
+        blockService.blockUserByPostId(memberId, postId);
+        return ResponseEntity.ok(ResponseDto.of(null));
+    }
+
+    @Operation(summary = "댓글/대댓글 작성자 차단",
+            description = "ReplyResponseDto/ReReplyResponseDto도 memberId를 내려주지 않는다. replyId만으로 차단한다.")
+    @SecurityRequirement(name = "Auth")
+    @PostMapping("/by-reply/{replyId}")
+    public ResponseEntity<ResponseDto<Void>> blockUserByReplyId(@PathVariable Long replyId, @AuthenticationPrincipal UserDetails userDetails) {
+        Long memberId = Long.parseLong(userDetails.getUsername());
+        blockService.blockUserByReplyId(memberId, replyId);
+        return ResponseEntity.ok(ResponseDto.of(null));
+    }
+
     @Operation(summary = "차단 해제")
     @SecurityRequirement(name = "Auth")
     @DeleteMapping("/{targetMemberId}")

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/BlockService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/member/service/BlockService.java
@@ -6,6 +6,10 @@ import kr.inuappcenterportal.inuportal.domain.member.model.Member;
 import kr.inuappcenterportal.inuportal.domain.member.repository.BlockRepository;
 import kr.inuappcenterportal.inuportal.domain.member.repository.FriendRepository;
 import kr.inuappcenterportal.inuportal.domain.member.repository.MemberRepository;
+import kr.inuappcenterportal.inuportal.domain.post.model.Post;
+import kr.inuappcenterportal.inuportal.domain.post.repository.PostRepository;
+import kr.inuappcenterportal.inuportal.domain.reply.model.Reply;
+import kr.inuappcenterportal.inuportal.domain.reply.repository.ReplyRepository;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
 import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +26,8 @@ public class BlockService {
     private final BlockRepository blockRepository;
     private final MemberRepository memberRepository;
     private final FriendRepository friendRepository;
+    private final PostRepository postRepository;
+    private final ReplyRepository replyRepository;
 
     @Transactional
     public void blockUser(Long memberId, Long targetMemberId) {
@@ -30,6 +36,52 @@ public class BlockService {
         Member blocked = memberRepository.findById(targetMemberId)
                 .orElseThrow(() -> new MyException(MyErrorCode.USER_NOT_FOUND));
 
+        blockUser(blocker, blocked);
+    }
+
+    /**
+     * 게시글 작성자 차단. 익명 글도 작성자(member)는 항상 서버에 남아있으므로 차단 자체는
+     * 가능하다 - 다만 PostResponseDto/PostListResponseDto는 memberId를 클라이언트에 절대
+     * 내려주지 않는다(글쓴이 재식별로 익명성이 깨지는 것을 막기 위해). 그래서 클라이언트가
+     * memberId를 몰라도 postId만으로 차단할 수 있도록 이 경로를 따로 둔다.
+     */
+    @Transactional
+    public void blockUserByPostId(Long memberId, Long postId) {
+        Member blocker = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MyException(MyErrorCode.USER_NOT_FOUND));
+
+        Post post = postRepository.findByIdAndIsDeletedFalse(postId)
+                .orElseThrow(() -> new MyException(MyErrorCode.POST_NOT_FOUND));
+
+        Member blocked = post.getMember();
+        if (blocked == null) {
+            throw new MyException(MyErrorCode.USER_NOT_FOUND);
+        }
+
+        blockUser(blocker, blocked);
+    }
+
+    /**
+     * 댓글/대댓글 작성자 차단. 사유는 blockUserByPostId와 동일 - Reply/ReReplyResponseDto도
+     * memberId를 내려주지 않는다.
+     */
+    @Transactional
+    public void blockUserByReplyId(Long memberId, Long replyId) {
+        Member blocker = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MyException(MyErrorCode.USER_NOT_FOUND));
+
+        Reply reply = replyRepository.findByIdAndIsDeletedFalse(replyId)
+                .orElseThrow(() -> new MyException(MyErrorCode.REPLY_NOT_FOUND));
+
+        Member blocked = reply.getMember();
+        if (blocked == null) {
+            throw new MyException(MyErrorCode.USER_NOT_FOUND);
+        }
+
+        blockUser(blocker, blocked);
+    }
+
+    private void blockUser(Member blocker, Member blocked) {
         if (blocker.getId().equals(blocked.getId())) {
             throw new MyException(MyErrorCode.NOT_SELF_BLOCK);
         }

--- a/src/test/java/kr/inuappcenterportal/inuportal/member/BlockServiceTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/member/BlockServiceTest.java
@@ -1,0 +1,157 @@
+package kr.inuappcenterportal.inuportal.member;
+
+import kr.inuappcenterportal.inuportal.domain.member.model.Member;
+import kr.inuappcenterportal.inuportal.domain.member.repository.BlockRepository;
+import kr.inuappcenterportal.inuportal.domain.member.repository.FriendRepository;
+import kr.inuappcenterportal.inuportal.domain.member.repository.MemberRepository;
+import kr.inuappcenterportal.inuportal.domain.member.service.BlockService;
+import kr.inuappcenterportal.inuportal.domain.post.model.Post;
+import kr.inuappcenterportal.inuportal.domain.post.repository.PostRepository;
+import kr.inuappcenterportal.inuportal.domain.reply.model.Reply;
+import kr.inuappcenterportal.inuportal.domain.reply.repository.ReplyRepository;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyErrorCode;
+import kr.inuappcenterportal.inuportal.global.exception.ex.MyException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * PostResponseDto/ReplyResponseDto가 memberId를 내려주지 않아(#294 관련,
+ * 익명 글/댓글 재식별 방지) 클라이언트가 postId/replyId만으로 작성자를 차단할 수
+ * 있어야 한다는 요구사항을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class BlockServiceTest {
+
+    @Mock
+    private BlockRepository blockRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private FriendRepository friendRepository;
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private ReplyRepository replyRepository;
+
+    @InjectMocks
+    private BlockService blockService;
+
+    private Member memberWithId(long id, String studentId) {
+        Member member = Member.builder().studentId(studentId).roles(List.of("ROLE_USER")).build();
+        ReflectionTestUtils.setField(member, "id", id);
+        return member;
+    }
+
+    @Test
+    @DisplayName("postId만으로 게시글 작성자를 차단할 수 있다 (익명 글 포함)")
+    void blockUserByPostId_success() {
+        Member blocker = memberWithId(1L, "202000001");
+        Member writer = memberWithId(2L, "202000002");
+        Post anonymousPost = Post.builder()
+                .title("t").content("c").category("free").anonymous(true).member(writer).imageCount(0).build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(postRepository.findByIdAndIsDeletedFalse(10L)).thenReturn(Optional.of(anonymousPost));
+        when(blockRepository.existsByBlockerAndBlocked(blocker, writer)).thenReturn(false);
+        when(friendRepository.findByRequesterAndReceiver(any(), any())).thenReturn(Optional.empty());
+
+        blockService.blockUserByPostId(1L, 10L);
+
+        verify(blockRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글이면 POST_NOT_FOUND")
+    void blockUserByPostId_postNotFound() {
+        Member blocker = memberWithId(1L, "202000001");
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(postRepository.findByIdAndIsDeletedFalse(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> blockService.blockUserByPostId(1L, 999L))
+                .isInstanceOf(MyException.class)
+                .extracting(e -> ((MyException) e).getErrorCode())
+                .isEqualTo(MyErrorCode.POST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("본인 글을 차단 시도하면 NOT_SELF_BLOCK, block은 저장되지 않는다")
+    void blockUserByPostId_selfBlockRejected() {
+        Member self = memberWithId(1L, "202000001");
+        Post ownPost = Post.builder()
+                .title("t").content("c").category("free").anonymous(false).member(self).imageCount(0).build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(self));
+        when(postRepository.findByIdAndIsDeletedFalse(10L)).thenReturn(Optional.of(ownPost));
+
+        assertThatThrownBy(() -> blockService.blockUserByPostId(1L, 10L))
+                .isInstanceOf(MyException.class)
+                .extracting(e -> ((MyException) e).getErrorCode())
+                .isEqualTo(MyErrorCode.NOT_SELF_BLOCK);
+
+        verify(blockRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("replyId만으로 댓글 작성자를 차단할 수 있다 (익명 댓글 포함)")
+    void blockUserByReplyId_success() {
+        Member blocker = memberWithId(1L, "202000001");
+        Member writer = memberWithId(2L, "202000002");
+        Post post = Post.builder()
+                .title("t").content("c").category("free").anonymous(false).member(writer).imageCount(0).build();
+        Reply anonymousReply = new Reply("hi", post, true, writer, null, 1L);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(replyRepository.findByIdAndIsDeletedFalse(20L)).thenReturn(Optional.of(anonymousReply));
+        when(blockRepository.existsByBlockerAndBlocked(blocker, writer)).thenReturn(false);
+        when(friendRepository.findByRequesterAndReceiver(any(), any())).thenReturn(Optional.empty());
+
+        blockService.blockUserByReplyId(1L, 20L);
+
+        verify(blockRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글이면 REPLY_NOT_FOUND")
+    void blockUserByReplyId_replyNotFound() {
+        Member blocker = memberWithId(1L, "202000001");
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(replyRepository.findByIdAndIsDeletedFalse(999L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> blockService.blockUserByReplyId(1L, 999L))
+                .isInstanceOf(MyException.class)
+                .extracting(e -> ((MyException) e).getErrorCode())
+                .isEqualTo(MyErrorCode.REPLY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이미 차단한 작성자의 다른 글이면 조용히 무시하고 중복 저장하지 않는다")
+    void blockUserByPostId_alreadyBlocked_noop() {
+        Member blocker = memberWithId(1L, "202000001");
+        Member writer = memberWithId(2L, "202000002");
+        Post post = Post.builder()
+                .title("t").content("c").category("free").anonymous(false).member(writer).imageCount(0).build();
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(blocker));
+        when(postRepository.findByIdAndIsDeletedFalse(10L)).thenReturn(Optional.of(post));
+        when(blockRepository.existsByBlockerAndBlocked(blocker, writer)).thenReturn(true);
+
+        blockService.blockUserByPostId(1L, 10L);
+
+        verify(blockRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
UGC 가이드라인 준수를 위해서 구현헀습니다

- postId/replyId만으로 서버가 작성자를 찾아 차단하는 엔드포인트를 추가
- 클라이언트는 memberId를 모른 채로 차단할 수 있다.

- POST /api/blocks/by-post/{postId} 구현
- POST /api/blocks/by-reply/{replyId} (대댓글도 같은 Reply 엔티티라 동일 경로로 처리)
- BlockService.blockUser(Long, Long)의 자기차단/중복차단/친구관계 해제 로직은 private blockUser(Member, Member)로 공용화해 세 진입점이 모두 공유
- BlockServiceTest 
  - 성공
  - 게시글없음
  - 자기차단
  - 댓글없음
  - 중복차단 무시
  - 익명 
정도 케이스 추가해서 테스트

## 확인
- ./gradlew compileJava compileTestJava 통과
