### PR TITLE
fix: 댓글 알림 이력 저장 실패 시 댓글 저장 트랜잭션까지 롤백되는 문제 수정

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -40,6 +40,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.PreparedStatement;
@@ -426,13 +427,20 @@ public class FcmService {
 
     /**
      * DB에 이력을 남기면서(알림함 노출) 푸시 알림을 보냅니다.
+     * REQUIRES_NEW: 이 메서드는 댓글/게시글 저장 같은 상위 트랜잭션 도중 "부가 기능"으로
+     * 호출되는 경우가 많다(예: ReplyService.saveReply). 알림 이력 저장에서 예외가 나면
+     * (예: fcm_message_type 컬럼 불일치) 호출부가 그 예외를 잡아 로그만 남기고 넘어가더라도,
+     * 같은 트랜잭션에 참여한 상태였다면 Spring이 이미 상위 트랜잭션을 rollback-only로
+     * 마킹해버려서 상위 메서드가 정상 반환해도 커밋 시점에 UnexpectedRollbackException이
+     * 터진다. REQUIRES_NEW로 별도 트랜잭션을 태워서 알림 이력 저장 실패가 상위(댓글/게시글
+     * 저장 등) 트랜잭션에 영향을 주지 않도록 격리한다.
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public TrackedNotificationDispatch prepareTrackedNotification(List<Long> memberIds, String title, String body, FcmMessageType type, Long targetId) {
         return prepareTrackedNotification(memberIds, title, body, type, targetId, null);
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public TrackedNotificationDispatch prepareTrackedNotification(List<Long> memberIds, String title, String body, FcmMessageType type, Long targetId, String path) {
         if (memberIds == null || memberIds.isEmpty()) {
             return null;


### PR DESCRIPTION
## 문제

`POST /api/replies/{postId}` 호출 시 dev 서버에서 500이 발생. 서버 로그 확인 결과 실제 원인은:

```
DataIntegrityViolationException: ... Data truncated for column 'fcm_message_type' at row 1
```

`FcmMessageType`에 새로 추가된 `POST_REPLY` 값이 dev DB의 `member_fcm_message.fcm_message_type` 컬럼(네이티브 ENUM)에는 반영되어 있지 않아 INSERT가 실패함.

## 얘 뭐라는거예요? FCM이 실패하면서 트랜잭션으로 같이 묶인 댓글 작성까지 박살나고 전송 과정에서 롤백만 하게끔 동작 되는 것 같고 .. 

`FcmService.prepareTrackedNotification()`은 `@Transactional`이고, `ReplyService.saveReply()`가 연 트랜잭션에 참여한 채로 호출됨. 이 메서드 안에서 예외가 발생하면 그 메서드 경계를 빠져나가는 순간 Spring이 **참여 중인 상위 트랜잭션을 rollback-only로 마킹**함.

`ReplyService.sendReplyNotification()`이 try/catch로 이 예외를 잡아 로그만 남기고 넘어가지만, 이미 상위 트랜잭션은 rollback-only 상태라 `saveReply()`가 정상 반환해도 커밋 시점에 `UnexpectedRollbackException`이 발생 → 어떤 `@ExceptionHandler`도 처리 못 해서 500 → 댓글 저장 자체가 롤백됨(로그엔 replyId가 찍히지만 실제 DB엔 저장 안 됨).

## 수정

`FcmService.prepareTrackedNotification()`(양쪽 오버로드)을 `Propagation.REQUIRES_NEW`로 변경해 알림 이력 저장을 별도 트랜잭션으로 격리. 알림 저장이 실패해도 댓글/게시글 저장 등 상위 트랜잭션에 영향을 주지 않도록 함.


## 테스트

- `./gradlew compileJava` 통과 확인