### PR TITLE
✨ feat: 개선 및 신규 기능 공식 정원실제 수강 인원담은 인원 3종 api 제공 확인

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
@@ -1,5 +1,6 @@
 package kr.inuappcenterportal.inuportal.domain.course.dto.courseOffering;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import kr.inuappcenterportal.inuportal.domain.course.dto.courseMeeting.CourseMeetingResponseDto;
 import kr.inuappcenterportal.inuportal.domain.course.model.CourseOffering;
 import kr.inuappcenterportal.inuportal.domain.semester.enums.SemesterTerm;
@@ -52,9 +53,13 @@ public record CourseOfferingResponseDto(
 
         Integer credit,
 
+        @Schema(description = "공식 정원. 편람/정원 엑셀에서 파싱된 값이며, 원천 데이터가 없으면 null입니다.")
         Integer capacity,
 
+        @Schema(description = "실제 수강 인원. 현재 원천 데이터 미연동 시 null입니다.")
         Integer enrolledCount,
+
+        @Schema(description = "포털 앱 내 시간표에 해당 강의를 담은 회원 수입니다.")
         Long savedCount,
 
         String hussCourseYn,

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
@@ -2,6 +2,7 @@ package kr.inuappcenterportal.inuportal.domain.course.dto.courseOffering;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import kr.inuappcenterportal.inuportal.domain.course.dto.courseMeeting.CourseMeetingResponseDto;
+import kr.inuappcenterportal.inuportal.domain.course.enums.courseOffering.ISU_NAME;
 import kr.inuappcenterportal.inuportal.domain.course.model.CourseOffering;
 import kr.inuappcenterportal.inuportal.domain.semester.enums.SemesterTerm;
 
@@ -56,11 +57,13 @@ public record CourseOfferingResponseDto(
         @Schema(description = "공식 정원. 편람/정원 엑셀에서 파싱된 값이며, 원천 데이터가 없으면 null입니다.")
         Integer capacity,
 
-        @Schema(description = "실제 수강 인원. 현재 원천 데이터 미연동 시 null입니다.")
+        @Schema(description = "실제 수강 인원. 햔재 제공하지 않는 데이터입니다.")
         Integer enrolledCount,
 
         @Schema(description = "포털 앱 내 시간표에 해당 강의를 담은 회원 수입니다.")
         Long savedCount,
+
+        String capacityNullReason,
 
         String hussCourseYn,
         String note,
@@ -68,7 +71,10 @@ public record CourseOfferingResponseDto(
 ) {
 
     // 교수명 노출 제한을 신경 쓰지 않는 내부 코드나 테스트, 혹은 기존 호출부 호환용
-    public static CourseOfferingResponseDto from(CourseOffering courseOffering, List<CourseMeetingResponseDto> meetings) {
+    public static CourseOfferingResponseDto from(
+            CourseOffering courseOffering,
+            List<CourseMeetingResponseDto> meetings
+    ) {
         return from(courseOffering, meetings, true, 0L);
     }
 
@@ -125,6 +131,7 @@ public record CourseOfferingResponseDto(
                 courseOffering.getCapacity(),
                 courseOffering.getEnrolledCount(),
                 savedCount,
+                resolveCapacityNullReason(courseOffering),
                 courseOffering.getHussCourseYn(),
                 courseOffering.getNote(),
                 meetings
@@ -133,5 +140,20 @@ public record CourseOfferingResponseDto(
 
     private static String valueOrFallback(String value, String fallback) {
         return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static String resolveCapacityNullReason(CourseOffering courseOffering) {
+        // 정원이 존재하면 nullReason은 null
+        if (courseOffering.getCapacity() != null) {
+            return null;
+        }
+
+        // 정원이 존재하지 않을 때 교양이면 파싱 실패
+        if (courseOffering.getIsuName().equals(ISU_NAME.ADVANCED_LIBERAL_ARTS) || courseOffering.getIsuName().equals(ISU_NAME.BASIC_LIBERAL_ARTS) || courseOffering.getIsuName().equals(ISU_NAME.CORE_LIBERAL_ARTS)) {
+            return "PARSE_FAILED";
+        }
+
+        // 그 외라면 정원 데이터 제공 불가
+        return "CAPACITY_NOT_AVAILABLE";
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/course/dto/courseOffering/CourseOfferingResponseDto.java
@@ -57,12 +57,17 @@ public record CourseOfferingResponseDto(
         @Schema(description = "공식 정원. 편람/정원 엑셀에서 파싱된 값이며, 원천 데이터가 없으면 null입니다.")
         Integer capacity,
 
-        @Schema(description = "실제 수강 인원. 햔재 제공하지 않는 데이터입니다.")
+        @Schema(description = "실제 수강 인원. 현재 제공하지 않는 데이터입니다.")
         Integer enrolledCount,
 
         @Schema(description = "포털 앱 내 시간표에 해당 강의를 담은 회원 수입니다.")
         Long savedCount,
 
+        @Schema(description = """
+                공식 정원이 null인 사유입니다. capacity 값이 있으면 null입니다.
+                - PARSE_FAILED: 교양 과목이지만 정원 정보 파싱에 실패했습니다.
+                - CAPACITY_NOT_AVAILABLE: 교양 외 과목이라 정원 데이터를 제공하지 않습니다.
+                """)
         String capacityNullReason,
 
         String hussCourseYn,


### PR DESCRIPTION
## 📎 관련 이슈

- closed #이슈번호

## 📄 설명

- 담은 인원 필드는 이미 savedCount로 관리되어 있음
- 따라서 enrolledCount는 현재 사용하지 않는 값. 지우는 것보다 나중을 위해 남겨두기로 결정(수정할 게 많아져서...)
- 정원 데이터가 null일때 응답 dto에서 이유 찾아서 리턴하게 필드 추가 및 메서드 추가
- null이유 코드에 대해 스웨거 설명 추가

## 🤔 추후 작업 사항

- ex) 성능 개선 필요