### PR TITLE
386 fix 알림 목록 읽음 처리가 페이지 전체를 읽어야만 하는 문제 수정

### DIFF
--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/model/MemberFcmMessage.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/model/MemberFcmMessage.java
@@ -59,8 +59,5 @@ public class MemberFcmMessage extends BaseTimeEntity {
 
     public void incrementViewCount() {
         this.viewCount += 1;
-        if (this.viewCount >= 2) {
-            markAsRead();
-        }
     }
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/repository/MemberFcmMessageRepository.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/repository/MemberFcmMessageRepository.java
@@ -4,7 +4,11 @@ import kr.inuappcenterportal.inuportal.domain.firebase.model.MemberFcmMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemberFcmMessageRepository extends JpaRepository<MemberFcmMessage, Long> {
@@ -12,6 +16,16 @@ public interface MemberFcmMessageRepository extends JpaRepository<MemberFcmMessa
     Page<MemberFcmMessage> findAllByMemberId(Long memberId, Pageable pageable);
 
     boolean existsByMemberIdAndIsReadFalse(Long memberId);
+
+    boolean existsByMemberIdAndIsReadFalseAndViewCountLessThan(Long memberId, int viewCount);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE MemberFcmMessage m SET m.isRead = true, m.readAt = :now WHERE m.memberId = :memberId AND m.isRead = false AND m.viewCount >= :threshold")
+    int markAsReadByViewCount(@Param("memberId") Long memberId, @Param("threshold") int threshold, @Param("now") LocalDateTime now);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE MemberFcmMessage m SET m.viewCount = m.viewCount + 1 WHERE m.memberId = :memberId AND m.isRead = false")
+    int incrementViewCountForAllUnread(@Param("memberId") Long memberId);
 
     Optional<MemberFcmMessage> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -482,10 +482,17 @@ public class FcmService {
 
     @Transactional
     public ListResponseDto<NotificationResponse> findNotifications(Member member, int page) {
-        Pageable pageable = PageRequest.of(page > 0 ? --page : page, 10, Sort.by(Sort.Order.asc("isRead"), Sort.Order.desc("id")));
-        Page<MemberFcmMessage> messages = memberFcmMessageRepository.findAllByMemberId(member.getId(), pageable);
+        int pageIndex = page > 0 ? page - 1 : page;
 
-        messages.forEach(MemberFcmMessage::incrementViewCount);
+        if (pageIndex == 0 && member != null) {
+            // 1. 이전 방문들에서 이미 2회 이상 조회된 알림들을 일괄 읽음 처리
+            memberFcmMessageRepository.markAsReadByViewCount(member.getId(), 2, LocalDateTime.now());
+            // 2. 현재 회원의 모든 안 읽은 알림의 viewCount를 일괄 1 증가 (페이지 스크롤 여부에 상관없이 전체 적용)
+            memberFcmMessageRepository.incrementViewCountForAllUnread(member.getId());
+        }
+
+        Pageable pageable = PageRequest.of(pageIndex, 10, Sort.by(Sort.Order.asc("isRead"), Sort.Order.desc("id")));
+        Page<MemberFcmMessage> messages = memberFcmMessageRepository.findAllByMemberId(member.getId(), pageable);
 
         Map<Long, FcmMessage> fcmMessageMap = fcmMessageRepository.findAllById(
                         messages.stream().map(MemberFcmMessage::getFcmMessageId).toList()
@@ -518,7 +525,7 @@ public class FcmService {
         if (member == null) {
             return false;
         }
-        return memberFcmMessageRepository.existsByMemberIdAndIsReadFalse(member.getId());
+        return memberFcmMessageRepository.existsByMemberIdAndIsReadFalseAndViewCountLessThan(member.getId(), 2);
     }
 
     private MulticastMessage createMulticastMessage(List<String> tokens, String title, String body, FcmMessageType type, Long targetId) {

--- a/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
+++ b/src/main/java/kr/inuappcenterportal/inuportal/domain/firebase/service/FcmService.java
@@ -491,7 +491,7 @@ public class FcmService {
             memberFcmMessageRepository.incrementViewCountForAllUnread(member.getId());
         }
 
-        Pageable pageable = PageRequest.of(pageIndex, 10, Sort.by(Sort.Order.asc("isRead"), Sort.Order.desc("id")));
+        Pageable pageable = PageRequest.of(pageIndex, 10, Sort.by(Sort.Direction.DESC, "id"));
         Page<MemberFcmMessage> messages = memberFcmMessageRepository.findAllByMemberId(member.getId(), pageable);
 
         Map<Long, FcmMessage> fcmMessageMap = fcmMessageRepository.findAllById(

--- a/src/test/java/kr/inuappcenterportal/inuportal/firebase/FcmNotificationSortTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/firebase/FcmNotificationSortTest.java
@@ -26,6 +26,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -112,10 +113,10 @@ class FcmNotificationSortTest {
         assertEquals(4, contents.size());
 
         // 순서 검증:
-        // 1등: m4 (안 읽음, id 더 큼)
-        // 2등: m2 (안 읽음, id 더 작음)
-        // 3등: m3 (읽음, id 더 큼)
-        // 4등: m1 (읽음, id 더 작음)
+        // 1등: m4 (안 읽음, 최신)
+        // 2등: m2 (안 읽음, 이전)
+        // 3등: m3 (읽음, 최신)
+        // 4등: m1 (읽음, 이전)
         assertEquals(m4.getId(), contents.get(0).memberFcmMessageId());
         assertFalse(contents.get(0).isRead());
 
@@ -130,33 +131,88 @@ class FcmNotificationSortTest {
     }
 
     @Test
-    @DisplayName("알림을 2회 조회하면 자동으로 읽음 처리된다.")
-    void viewCountIncrementAndAutoReadTest() {
+    @DisplayName("페이지에 상관없이 회원의 모든 안 읽은 알림이 2회 진입 후 3번째 진입 시 일괄 읽음 처리된다.")
+    void pageAgnosticAutoReadTest() {
         Member member = memberRepository.save(Member.builder()
                 .studentId("202000002")
                 .roles(Collections.singletonList("ROLE_USER"))
                 .build());
 
-        FcmMessage msg = fcmMessageRepository.save(FcmMessage.builder().title("알림").body("본문").build());
-        MemberFcmMessage memberMsg = memberFcmMessageRepository.save(
-                MemberFcmMessage.of(msg.getId(), member.getId(), FcmMessageType.GENERAL)
-        );
+        // 15개의 안 읽은 알림 생성 (1페이지 10개, 2페이지 5개)
+        List<MemberFcmMessage> messages = new ArrayList<>();
+        for (int i = 1; i <= 15; i++) {
+            FcmMessage msg = fcmMessageRepository.save(FcmMessage.builder().title("알림 " + i).body("본문 " + i).build());
+            messages.add(memberFcmMessageRepository.save(
+                    MemberFcmMessage.of(msg.getId(), member.getId(), FcmMessageType.GENERAL)
+            ));
+        }
 
-        // 첫 번째 조회 -> viewCount = 1, isRead = false
-        ListResponseDto<NotificationResponse> firstFetch = fcmService.findNotifications(member, 1);
-        assertFalse(firstFetch.getContents().get(0).isRead());
+        // [1번째 방문]: 1페이지(1~10번)만 조회하고 나감
+        ListResponseDto<NotificationResponse> visit1 = fcmService.findNotifications(member, 1);
+        assertEquals(10, visit1.getContents().size());
+        assertFalse(visit1.getContents().get(0).isRead());
+        assertTrue(fcmService.hasUnreadNotification(member));
 
-        MemberFcmMessage afterFirst = memberFcmMessageRepository.findById(memberMsg.getId()).orElseThrow();
-        assertEquals(1, afterFirst.getViewCount());
-        assertFalse(afterFirst.isRead());
+        // 1페이지에 있던 알림뿐만 아니라 2페이지에 있던 알림(11~15번)도 모두 viewCount = 1
+        for (MemberFcmMessage msg : messages) {
+            MemberFcmMessage loaded = memberFcmMessageRepository.findById(msg.getId()).orElseThrow();
+            assertEquals(1, loaded.getViewCount());
+            assertFalse(loaded.isRead());
+        }
 
-        // 두 번째 조회 -> viewCount = 2, isRead = true
-        ListResponseDto<NotificationResponse> secondFetch = fcmService.findNotifications(member, 1);
-        assertTrue(secondFetch.getContents().get(0).isRead());
+        // [2번째 방문]: 1페이지 조회 -> viewCount = 2, 화면에는 여전히 isRead = false
+        ListResponseDto<NotificationResponse> visit2 = fcmService.findNotifications(member, 1);
+        assertFalse(visit2.getContents().get(0).isRead());
+        assertFalse(fcmService.hasUnreadNotification(member));
 
-        MemberFcmMessage afterSecond = memberFcmMessageRepository.findById(memberMsg.getId()).orElseThrow();
-        assertEquals(2, afterSecond.getViewCount());
-        assertTrue(afterSecond.isRead());
-        assertNotNull(afterSecond.getReadAt());
+        for (MemberFcmMessage msg : messages) {
+            MemberFcmMessage loaded = memberFcmMessageRepository.findById(msg.getId()).orElseThrow();
+            assertEquals(2, loaded.getViewCount());
+        }
+
+        // [3번째 방문]: 1페이지 조회 -> 2회 조회가 완료되었으므로 15개 전체 알림이 일괄 isRead = true로 전환됨
+        ListResponseDto<NotificationResponse> visit3 = fcmService.findNotifications(member, 1);
+        assertTrue(visit3.getContents().get(0).isRead());
+
+        for (MemberFcmMessage msg : messages) {
+            MemberFcmMessage loaded = memberFcmMessageRepository.findById(msg.getId()).orElseThrow();
+            assertTrue(loaded.isRead());
+            assertNotNull(loaded.getReadAt());
+        }
+    }
+
+    @Test
+    @DisplayName("인피니티 스크롤 시(1p -> 2p) 정렬 순서가 흔들리지 않고 순차적으로 깨끗하게 조회된다.")
+    void infiniteScrollConsistencyTest() {
+        Member member = memberRepository.save(Member.builder()
+                .studentId("202000003")
+                .roles(Collections.singletonList("ROLE_USER"))
+                .build());
+
+        // 안 읽은 알림 15개 생성
+        for (int i = 1; i <= 15; i++) {
+            FcmMessage msg = fcmMessageRepository.save(FcmMessage.builder().title("알림 " + i).body("본문 " + i).build());
+            memberFcmMessageRepository.save(
+                    MemberFcmMessage.of(msg.getId(), member.getId(), FcmMessageType.GENERAL)
+            );
+        }
+
+        // 1페이지 조회 (10개)
+        ListResponseDto<NotificationResponse> page1 = fcmService.findNotifications(member, 1);
+        assertEquals(10, page1.getContents().size());
+
+        // 2페이지 조회 (5개)
+        ListResponseDto<NotificationResponse> page2 = fcmService.findNotifications(member, 2);
+        assertEquals(5, page2.getContents().size());
+
+        List<Long> page1Ids = page1.getContents().stream().map(NotificationResponse::memberFcmMessageId).toList();
+        List<Long> page2Ids = page2.getContents().stream().map(NotificationResponse::memberFcmMessageId).toList();
+
+        // 1페이지와 2페이지 아이템 ID에 중복이 전혀 없어야 함
+        for (Long id : page2Ids) {
+            assertFalse(page1Ids.contains(id), "2페이지 아이템이 1페이지에 중복 포함되어서는 안 됩니다: id=" + id);
+        }
+
+        assertEquals(15, page1Ids.size() + page2Ids.size());
     }
 }

--- a/src/test/java/kr/inuappcenterportal/inuportal/firebase/FcmNotificationSortTest.java
+++ b/src/test/java/kr/inuappcenterportal/inuportal/firebase/FcmNotificationSortTest.java
@@ -74,8 +74,8 @@ class FcmNotificationSortTest {
     MemberFcmMessageRepository memberFcmMessageRepository;
 
     @Test
-    @DisplayName("알림 조회 시 안 읽은 알림이 최신순으로 상단에 배치되고, 그 후 읽은 알림이 최신순으로 배치된다.")
-    void notificationSortOrderTest() {
+    @DisplayName("알림 조회 시 모든 알림이 최신순(id DESC)으로 정렬되어 반환된다.")
+    void notificationLatestSortTest() {
         Member member = memberRepository.save(Member.builder()
                 .studentId("202000001")
                 .roles(Collections.singletonList("ROLE_USER"))
@@ -87,24 +87,11 @@ class FcmNotificationSortTest {
         FcmMessage msg3 = fcmMessageRepository.save(FcmMessage.builder().title("알림 3").body("본문 3").build());
         FcmMessage msg4 = fcmMessageRepository.save(FcmMessage.builder().title("알림 4").body("본문 4").build());
 
-        // memberFcmMessage 생성
-        // msg1: 읽음 상태
-        MemberFcmMessage m1 = MemberFcmMessage.of(msg1.getId(), member.getId(), FcmMessageType.GENERAL);
-        m1.markAsRead();
-        m1 = memberFcmMessageRepository.save(m1);
-
-        // msg2: 안 읽은 상태 (오래된 안 읽은 알림)
-        MemberFcmMessage m2 = MemberFcmMessage.of(msg2.getId(), member.getId(), FcmMessageType.GENERAL);
-        m2 = memberFcmMessageRepository.save(m2);
-
-        // msg3: 읽음 상태 (최신 읽은 알림)
-        MemberFcmMessage m3 = MemberFcmMessage.of(msg3.getId(), member.getId(), FcmMessageType.GENERAL);
-        m3.markAsRead();
-        m3 = memberFcmMessageRepository.save(m3);
-
-        // msg4: 안 읽은 상태 (최신 안 읽은 알림)
-        MemberFcmMessage m4 = MemberFcmMessage.of(msg4.getId(), member.getId(), FcmMessageType.GENERAL);
-        m4 = memberFcmMessageRepository.save(m4);
+        // memberFcmMessage 생성 (순차적으로 생성)
+        MemberFcmMessage m1 = memberFcmMessageRepository.save(MemberFcmMessage.of(msg1.getId(), member.getId(), FcmMessageType.GENERAL));
+        MemberFcmMessage m2 = memberFcmMessageRepository.save(MemberFcmMessage.of(msg2.getId(), member.getId(), FcmMessageType.GENERAL));
+        MemberFcmMessage m3 = memberFcmMessageRepository.save(MemberFcmMessage.of(msg3.getId(), member.getId(), FcmMessageType.GENERAL));
+        MemberFcmMessage m4 = memberFcmMessageRepository.save(MemberFcmMessage.of(msg4.getId(), member.getId(), FcmMessageType.GENERAL));
 
         // 조회 실행
         ListResponseDto<NotificationResponse> result = fcmService.findNotifications(member, 1);
@@ -112,22 +99,11 @@ class FcmNotificationSortTest {
 
         assertEquals(4, contents.size());
 
-        // 순서 검증:
-        // 1등: m4 (안 읽음, 최신)
-        // 2등: m2 (안 읽음, 이전)
-        // 3등: m3 (읽음, 최신)
-        // 4등: m1 (읽음, 이전)
+        // 순수 최신순(id DESC) 정렬 검증: m4 -> m3 -> m2 -> m1
         assertEquals(m4.getId(), contents.get(0).memberFcmMessageId());
-        assertFalse(contents.get(0).isRead());
-
-        assertEquals(m2.getId(), contents.get(1).memberFcmMessageId());
-        assertFalse(contents.get(1).isRead());
-
-        assertEquals(m3.getId(), contents.get(2).memberFcmMessageId());
-        assertTrue(contents.get(2).isRead());
-
+        assertEquals(m3.getId(), contents.get(1).memberFcmMessageId());
+        assertEquals(m2.getId(), contents.get(2).memberFcmMessageId());
         assertEquals(m1.getId(), contents.get(3).memberFcmMessageId());
-        assertTrue(contents.get(3).isRead());
     }
 
     @Test
@@ -147,13 +123,13 @@ class FcmNotificationSortTest {
             ));
         }
 
-        // [1번째 방문]: 1페이지(1~10번)만 조회하고 나감
+        // [1번째 방문]: 1페이지(최신 10개)만 조회하고 나감
         ListResponseDto<NotificationResponse> visit1 = fcmService.findNotifications(member, 1);
         assertEquals(10, visit1.getContents().size());
         assertFalse(visit1.getContents().get(0).isRead());
         assertTrue(fcmService.hasUnreadNotification(member));
 
-        // 1페이지에 있던 알림뿐만 아니라 2페이지에 있던 알림(11~15번)도 모두 viewCount = 1
+        // 1페이지에 있던 알림뿐만 아니라 2페이지에 있던 알림(오래된 5개)도 모두 viewCount = 1
         for (MemberFcmMessage msg : messages) {
             MemberFcmMessage loaded = memberFcmMessageRepository.findById(msg.getId()).orElseThrow();
             assertEquals(1, loaded.getViewCount());
@@ -182,7 +158,7 @@ class FcmNotificationSortTest {
     }
 
     @Test
-    @DisplayName("인피니티 스크롤 시(1p -> 2p) 정렬 순서가 흔들리지 않고 순차적으로 깨끗하게 조회된다.")
+    @DisplayName("인피니티 스크롤 시(1p -> 2p) 정렬 순서가 흔들리지 않고 순차적으로 깨끗하게 최신순으로 조회된다.")
     void infiniteScrollConsistencyTest() {
         Member member = memberRepository.save(Member.builder()
                 .studentId("202000003")
@@ -197,11 +173,11 @@ class FcmNotificationSortTest {
             );
         }
 
-        // 1페이지 조회 (10개)
+        // 1페이지 조회 (최신 10개)
         ListResponseDto<NotificationResponse> page1 = fcmService.findNotifications(member, 1);
         assertEquals(10, page1.getContents().size());
 
-        // 2페이지 조회 (5개)
+        // 2페이지 조회 (그 다음 5개)
         ListResponseDto<NotificationResponse> page2 = fcmService.findNotifications(member, 2);
         assertEquals(5, page2.getContents().size());
 


### PR DESCRIPTION
## 📎 관련 이슈

- closed #386 

## 📄 설명

- 이번 PR에서 작업한 내용을 간략히 요약해 주세요.

## 🤔 추후 작업 사항

- ex) 성능 개선 필요